### PR TITLE
Feature/coveralls unit test reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: java
 
 jdk:
   - oraclejdk8
+
+after_success:
+  - mvn clean test jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <url>https://github.com/bullhorn/dataloader</url>
 
     <properties>
+        <coveralls-version>4.2.0</coveralls-version>
         <sdk-rest-version>1.1.13</sdk-rest-version>
         <java.version>1.8</java.version>
         <javacsv.version>2.0</javacsv.version>
@@ -146,6 +147,14 @@
                     <formats>
                         <format>zip</format>
                     </formats>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>${coveralls-version}</version>
+                <configuration>
+                    <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <coveralls-version>4.2.0</coveralls-version>
+        <jacoco-version>0.7.7.201606060606</jacoco-version>
         <sdk-rest-version>1.1.13</sdk-rest-version>
         <java.version>1.8</java.version>
         <javacsv.version>2.0</javacsv.version>
@@ -156,6 +157,19 @@
                 <configuration>
                     <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Added Unit Test Coverage to Travis-CI builds. With this commit, our unit tests that are run by Travis-CI will now be output to Coveralls for full test coverage tracking over time. This also brings us one step closer to integration of our test coverage into Galaxy.