### PR TITLE
Fixed ActionTotals for load/delete from directory

### DIFF
--- a/src/main/java/com/bullhorn/dataloader/task/AbstractTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/AbstractTask.java
@@ -212,7 +212,7 @@ public abstract class AbstractTask<B extends BullhornEntity> implements Runnable
 
         List<Method> methods = Arrays.asList(toOneEntityClass.getMethods()).stream().filter(n -> getMethodName.equalsIgnoreCase(n.getName())).collect(Collectors.toList());
         if (methods.isEmpty()) {
-            throw new IllegalArgumentException("To-One Association field: '" + fieldName + "' does not exist on " + toOneEntityClass.getSimpleName());
+            throw new RestApiException("To-One Association field: '" + fieldName + "' does not exist on " + toOneEntityClass.getSimpleName());
         }
 
         return methods.get(0).getReturnType();

--- a/src/main/java/com/bullhorn/dataloader/task/AbstractTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/AbstractTask.java
@@ -208,8 +208,14 @@ public abstract class AbstractTask<B extends BullhornEntity> implements Runnable
     }
 
     protected Class getFieldType(Class<B> toOneEntityClass, String fieldName) {
-        String getMethodName = "get"+fieldName;
-        return Arrays.asList(toOneEntityClass.getMethods()).stream().filter(n -> getMethodName.equalsIgnoreCase(n.getName())).collect(Collectors.toList()).get(0).getReturnType();
+        String getMethodName = "get" + fieldName;
+
+        List<Method> methods = Arrays.asList(toOneEntityClass.getMethods()).stream().filter(n -> getMethodName.equalsIgnoreCase(n.getName())).collect(Collectors.toList());
+        if (methods.isEmpty()) {
+            throw new IllegalArgumentException("To-One Association field: '" + fieldName + "' does not exist on " + toOneEntityClass.getSimpleName());
+        }
+
+        return methods.get(0).getReturnType();
     }
 
     protected void checkForRestSdkErrorMessages(CrudResponse response) {

--- a/src/main/java/com/bullhorn/dataloader/task/LoadTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/LoadTask.java
@@ -190,7 +190,7 @@ public class LoadTask< A extends AssociationEntity, E extends EntityAssociations
         String value = dataMap.get(field);
         Method method = methodMap.get(field.toLowerCase());
         if (method == null) {
-            throw new IllegalArgumentException("Invalid field: '" + field + "' does not exist on " + entity.getClass().getSimpleName());
+            throw new RestApiException("Invalid field: '" + field + "' does not exist on " + entity.getClass().getSimpleName());
         }
 
         if (value != null && !"".equalsIgnoreCase(value)){
@@ -205,7 +205,7 @@ public class LoadTask< A extends AssociationEntity, E extends EntityAssociations
         }
     }
 
-    private <S extends SearchEntity> void handleOneToOne(String field) throws InvocationTargetException, IllegalAccessException, IllegalArgumentException {
+    private <S extends SearchEntity> void handleOneToOne(String field) throws InvocationTargetException, IllegalAccessException, RestApiException {
         String toOneEntityName = field.substring(0, field.indexOf("."));
         String fieldName = field.substring(field.indexOf(".") + 1, field.length());
 
@@ -215,7 +215,7 @@ public class LoadTask< A extends AssociationEntity, E extends EntityAssociations
         else {
             Method method = methodMap.get(toOneEntityName.toLowerCase());
             if (method == null) {
-                throw new IllegalArgumentException("To-One Association: '" + toOneEntityName + "' does not exist on " + entity.getClass().getSimpleName());
+                throw new RestApiException("To-One Association: '" + toOneEntityName + "' does not exist on " + entity.getClass().getSimpleName());
             }
 
             Class<B> toOneEntityClass = (Class<B>) method.getParameterTypes()[0];
@@ -246,7 +246,7 @@ public class LoadTask< A extends AssociationEntity, E extends EntityAssociations
         } else {
             Method method = methodMap.get(fieldName);
             if (method == null) {
-                throw new IllegalArgumentException("Invalid field: '" + field + "' - '" + fieldName + "' does not exist on the Address object");
+                throw new RestApiException("Invalid field: '" + field + "' - '" + fieldName + "' does not exist on the Address object");
             }
 
             method.invoke(addressMap.get(toOneEntityName), dataMap.get(field));

--- a/src/main/java/com/bullhorn/dataloader/util/ActionTotals.java
+++ b/src/main/java/com/bullhorn/dataloader/util/ActionTotals.java
@@ -7,11 +7,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ActionTotals {
 
-	private static AtomicInteger totalUpdate = new AtomicInteger(0);
-	private static AtomicInteger totalInsert = new AtomicInteger(0);
-	private static AtomicInteger totalError = new AtomicInteger(0);
-	private static AtomicInteger totalConvert = new AtomicInteger(0);
-	private static AtomicInteger totalDelete = new AtomicInteger(0);
+	private AtomicInteger totalUpdate = new AtomicInteger(0);
+	private AtomicInteger totalInsert = new AtomicInteger(0);
+	private AtomicInteger totalError = new AtomicInteger(0);
+	private AtomicInteger totalConvert = new AtomicInteger(0);
+	private AtomicInteger totalDelete = new AtomicInteger(0);
 
 	public void incrementTotalInsert() {
 		totalInsert.incrementAndGet();

--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -224,7 +224,7 @@ public class LoadTaskTest {
     @Test
     public void run_invalidField() throws IOException, InstantiationException, IllegalAccessException {
         dataMap.put("bogus", "This should fail with meaningful error because the field bogus does not exist on Candidate.");
-        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: Invalid field: 'bogus' does not exist on Candidate");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "com.bullhornsdk.data.exception.RestApiException: Invalid field: 'bogus' does not exist on Candidate");
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
 
         when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));
@@ -251,7 +251,7 @@ public class LoadTaskTest {
     @Test
     public void run_invalidToOneAssociation() throws IOException, InstantiationException, IllegalAccessException {
         dataMap.put("bogus.id", "This should fail with meaningful error because bogus does not exist.");
-        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: To-One Association: 'bogus' does not exist on Candidate");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "com.bullhornsdk.data.exception.RestApiException: To-One Association: 'bogus' does not exist on Candidate");
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
 
         when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));
@@ -278,7 +278,7 @@ public class LoadTaskTest {
     @Test
     public void run_invalidToOneAssociationField() throws IOException, InstantiationException, IllegalAccessException {
         dataMap.put("owner.bogus", "This should fail with meaningful error because the field bogus does not exist on the owner to-one association.");
-        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: To-One Association field: 'bogus' does not exist on CorporateUser");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "com.bullhornsdk.data.exception.RestApiException: To-One Association field: 'bogus' does not exist on CorporateUser");
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
 
         when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));
@@ -305,7 +305,7 @@ public class LoadTaskTest {
     @Test
     public void run_invalidToOneAddressAssociationField() throws IOException, InstantiationException, IllegalAccessException {
         dataMap.put("secondaryAddress.bogus", "This should fail with meaningful error because the field bogus does not exist on the address to-one association.");
-        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: Invalid field: 'secondaryAddress.bogus' - 'bogus' does not exist on the Address object");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "com.bullhornsdk.data.exception.RestApiException: Invalid field: 'secondaryAddress.bogus' - 'bogus' does not exist on the Address object");
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
 
         when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));

--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -86,6 +86,7 @@ public class LoadTaskTest {
         methodMap = concurrencyService.createMethodMap(Candidate.class);
         countryNameToIdMap = new LinkedHashMap<String, Integer>();
         countryNameToIdMap.put("United States", 1);
+
         dataMap = new LinkedHashMap<String, String>();
         dataMap.put("externalID", "11");
         dataMap.put("firstName", "Load");
@@ -105,8 +106,8 @@ public class LoadTaskTest {
         task.entity = candidate;
         when(task.getAttachmentFilePath("Candidate", "11")).thenReturn("src/test/resources/convertedAttachments/Candidate/11.html");
 
+        Assert.assertNull(candidate.getDescription());
         task.insertAttachmentToDescription();
-
         Assert.assertNotNull(candidate.getDescription());
     }
 
@@ -118,9 +119,9 @@ public class LoadTaskTest {
         task.entity = corporation;
         when(task.getAttachmentFilePath("ClientCorporation", "11")).thenReturn("src/test/resources/convertedAttachments/Candidate/11.html");
 
+        // ClientCorporation uses companyDescription field instead of description
+        Assert.assertNull(corporation.getCompanyDescription());
         task.insertAttachmentToDescription();
-
-        //client corp uses companyDescription field instead of description
         Assert.assertNotNull(corporation.getCompanyDescription());
     }
 
@@ -221,9 +222,90 @@ public class LoadTaskTest {
     }
 
     @Test
-    public void run_UpdateError() throws IOException, InstantiationException, IllegalAccessException {
-        dataMap.put("bogus.bogus", "this should fail!");
-        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.NullPointerException");
+    public void run_invalidField() throws IOException, InstantiationException, IllegalAccessException {
+        dataMap.put("bogus", "This should fail with meaningful error because the field bogus does not exist on Candidate.");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: Invalid field: 'bogus' does not exist on Candidate");
+        task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
+
+        when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));
+        when(task.getAttachmentFilePath("Candidate", "11")).thenReturn("src/test/resources/convertedAttachments/Candidate/11.html");
+        when(bullhornDataMock.query(eq(CorporateUser.class), eq("id=1"), any(), any())).thenReturn(getListWrapper(CorporateUser.class));
+        when(bullhornDataMock.query(eq(Skill.class), eq("id=1"), any(), any())).thenReturn(getListWrapper(Skill.class));
+        UpdateResponse response = new UpdateResponse();
+        response.setChangedEntityId(1);
+        when(bullhornDataMock.updateEntity(any())).thenReturn(response);
+
+        task.run();
+
+        verify(csvFileWriterMock).writeRow(any(), resultArgumentCaptor.capture());
+        final Result actualResult = resultArgumentCaptor.getValue();
+        Assert.assertThat(actualResult, new ReflectionEquals(expectedResult));
+
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalInsert();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalUpdate();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalConvert();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalDelete();
+        Mockito.verify(actionTotalsMock, Mockito.times(1)).incrementTotalError();
+    }
+
+    @Test
+    public void run_invalidToOneAssociation() throws IOException, InstantiationException, IllegalAccessException {
+        dataMap.put("bogus.id", "This should fail with meaningful error because bogus does not exist.");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: To-One Association: 'bogus' does not exist on Candidate");
+        task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
+
+        when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));
+        when(task.getAttachmentFilePath("Candidate", "11")).thenReturn("src/test/resources/convertedAttachments/Candidate/11.html");
+        when(bullhornDataMock.query(eq(CorporateUser.class), eq("id=1"), any(), any())).thenReturn(getListWrapper(CorporateUser.class));
+        when(bullhornDataMock.query(eq(Skill.class), eq("id=1"), any(), any())).thenReturn(getListWrapper(Skill.class));
+        UpdateResponse response = new UpdateResponse();
+        response.setChangedEntityId(1);
+        when(bullhornDataMock.updateEntity(any())).thenReturn(response);
+
+        task.run();
+
+        verify(csvFileWriterMock).writeRow(any(), resultArgumentCaptor.capture());
+        final Result actualResult = resultArgumentCaptor.getValue();
+        Assert.assertThat(actualResult, new ReflectionEquals(expectedResult));
+
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalInsert();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalUpdate();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalConvert();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalDelete();
+        Mockito.verify(actionTotalsMock, Mockito.times(1)).incrementTotalError();
+    }
+
+    @Test
+    public void run_invalidToOneAssociationField() throws IOException, InstantiationException, IllegalAccessException {
+        dataMap.put("owner.bogus", "This should fail with meaningful error because the field bogus does not exist on the owner to-one association.");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: To-One Association field: 'bogus' does not exist on CorporateUser");
+        task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
+
+        when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));
+        when(task.getAttachmentFilePath("Candidate", "11")).thenReturn("src/test/resources/convertedAttachments/Candidate/11.html");
+        when(bullhornDataMock.query(eq(CorporateUser.class), eq("id=1"), any(), any())).thenReturn(getListWrapper(CorporateUser.class));
+        when(bullhornDataMock.query(eq(Skill.class), eq("id=1"), any(), any())).thenReturn(getListWrapper(Skill.class));
+        UpdateResponse response = new UpdateResponse();
+        response.setChangedEntityId(1);
+        when(bullhornDataMock.updateEntity(any())).thenReturn(response);
+
+        task.run();
+
+        verify(csvFileWriterMock).writeRow(any(), resultArgumentCaptor.capture());
+        final Result actualResult = resultArgumentCaptor.getValue();
+        Assert.assertThat(actualResult, new ReflectionEquals(expectedResult));
+
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalInsert();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalUpdate();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalConvert();
+        Mockito.verify(actionTotalsMock, Mockito.never()).incrementTotalDelete();
+        Mockito.verify(actionTotalsMock, Mockito.times(1)).incrementTotalError();
+    }
+
+    @Test
+    public void run_invalidToOneAddressAssociationField() throws IOException, InstantiationException, IllegalAccessException {
+        dataMap.put("secondaryAddress.bogus", "This should fail with meaningful error because the field bogus does not exist on the address to-one association.");
+        Result expectedResult = new Result(Result.Status.FAILURE, Result.Action.NOT_SET, 1, "java.lang.IllegalArgumentException: Invalid field: 'secondaryAddress.bogus' - 'bogus' does not exist on the Address object");
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, Candidate.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
 
         when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"11\""), any(), any())).thenReturn(getListWrapper(Candidate.class));

--- a/src/test/java/com/bullhorn/dataloader/util/ActionTotalsTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/ActionTotalsTest.java
@@ -8,38 +8,68 @@ import org.junit.Test;
 
 public class ActionTotalsTest {
 
-    private ActionTotals actionTotals;
+    private ActionTotals actionTotals1;
+    private ActionTotals actionTotals2;
 
     @Before
     public void setup() throws IOException {
-        actionTotals = new ActionTotals();
+        actionTotals1 = new ActionTotals();
+        actionTotals2 = new ActionTotals();
     }
 
     @Test
-    public void testIncrementTotalInsert() {
-        Assert.assertEquals(actionTotals.getTotalInsert(), 0);
-        actionTotals.incrementTotalInsert();
-        Assert.assertEquals(actionTotals.getTotalInsert(), 1);
+    public void testIncrementTotalInsert1() {
+        Assert.assertEquals(actionTotals1.getTotalInsert(), 0);
+        actionTotals1.incrementTotalInsert();
+        Assert.assertEquals(actionTotals1.getTotalInsert(), 1);
     }
 
     @Test
-    public void testIncrementTotalUpdate() {
-        Assert.assertEquals(actionTotals.getTotalUpdate(), 0);
-        actionTotals.incrementTotalUpdate();
-        Assert.assertEquals(actionTotals.getTotalUpdate(), 1);
+    public void testIncrementTotalInsert2() {
+        Assert.assertEquals(actionTotals2.getTotalInsert(), 0);
+        actionTotals2.incrementTotalInsert();
+        Assert.assertEquals(actionTotals2.getTotalInsert(), 1);
     }
 
     @Test
-    public void testIncrementTotalError() {
-        Assert.assertEquals(actionTotals.getTotalError(), 0);
-        actionTotals.incrementTotalError();
-        Assert.assertEquals(actionTotals.getTotalError(), 1);
+    public void testIncrementTotalUpdate1() {
+        Assert.assertEquals(actionTotals1.getTotalUpdate(), 0);
+        actionTotals1.incrementTotalUpdate();
+        Assert.assertEquals(actionTotals1.getTotalUpdate(), 1);
     }
 
     @Test
-    public void testIncrementTotalDelete() {
-        Assert.assertEquals(actionTotals.getTotalDelete(), 0);
-        actionTotals.incrementTotalDelete();
-        Assert.assertEquals(actionTotals.getTotalDelete(), 1);
+    public void testIncrementTotalUpdate2() {
+        Assert.assertEquals(actionTotals2.getTotalUpdate(), 0);
+        actionTotals2.incrementTotalUpdate();
+        Assert.assertEquals(actionTotals2.getTotalUpdate(), 1);
+    }
+
+    @Test
+    public void testIncrementTotalError1() {
+        Assert.assertEquals(actionTotals1.getTotalError(), 0);
+        actionTotals1.incrementTotalError();
+        Assert.assertEquals(actionTotals1.getTotalError(), 1);
+    }
+
+    @Test
+    public void testIncrementTotalError2() {
+        Assert.assertEquals(actionTotals2.getTotalError(), 0);
+        actionTotals2.incrementTotalError();
+        Assert.assertEquals(actionTotals2.getTotalError(), 1);
+    }
+
+    @Test
+    public void testIncrementTotalDelete1() {
+        Assert.assertEquals(actionTotals1.getTotalDelete(), 0);
+        actionTotals1.incrementTotalDelete();
+        Assert.assertEquals(actionTotals1.getTotalDelete(), 1);
+    }
+
+    @Test
+    public void testIncrementTotalDelete2() {
+        Assert.assertEquals(actionTotals2.getTotalDelete(), 0);
+        actionTotals2.incrementTotalDelete();
+        Assert.assertEquals(actionTotals2.getTotalDelete(), 1);
     }
 }


### PR DESCRIPTION
The count was tied to static variables that kept incrementing across files.
Increased test coverage of ActionTotals.