### PR TITLE
Fixed the bug where one or more of the first rows failed due to an ex…

### DIFF
--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -504,16 +504,6 @@ public class LoadTaskTest {
     }
 
     @Test
-    public void getAssociationFieldsTestCatch() {
-        List expectedResult = new ArrayList<>();
-        task = new LoadTask(Command.LOAD, 1, CandidateReference.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock);
-
-        List actualResult = task.getAssociationFields();
-
-        Assert.assertThat(expectedResult, new ReflectionEquals(actualResult));
-    }
-
-    @Test
     public void getGetMethodTestCatch() {
         task = new LoadTask(Command.LOAD, 1, CandidateReference.class, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock);
 


### PR DESCRIPTION
…ception

The error displayed is: ConcurrentModificationException, which arose because of the
way we are using a static factory pattern to grab a single instance of an EntityAssociations
object and then calling the allAssociations() method on that instance from multiple
threads concurrently. The creation of the array of values is what fails.