### PR TITLE
Updated to the latest version of SDK-REST and fixed unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <coveralls-version>4.2.0</coveralls-version>
         <jacoco-version>0.7.7.201606060606</jacoco-version>
-        <sdk-rest-version>1.1.17</sdk-rest-version>
+        <sdk-rest-version>1.1.18</sdk-rest-version>
         <apache-tika-version>1.13</apache-tika-version>
         <java.version>1.8</java.version>
         <javacsv.version>2.0</javacsv.version>

--- a/src/test/java/com/bullhorn/dataloader/util/TemplateUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/TemplateUtilTest.java
@@ -60,9 +60,9 @@ public class TemplateUtilTest {
         fax.setType(null);
         fax.setDataType(null);
 
-        Field childClientCorporations = new Field();
-        childClientCorporations.setName("childClientCorporations");
-        childClientCorporations.setType("TO_MANY");
+        Field leads = new Field();
+        leads.setName("leads");
+        leads.setType("TO_MANY");
 
         Field clientContacts = new Field();
         clientContacts.setName("clientContacts");
@@ -73,7 +73,7 @@ public class TemplateUtilTest {
         department.setType("TO_ONE");
 
         metaFieldSet.add(department);
-        metaFieldSet.add(childClientCorporations);
+        metaFieldSet.add(leads);
         metaFieldSet.add(fax);
         metaFieldSet.add(addressField);
         metaFieldSet.add(clientCorporationField);
@@ -160,7 +160,7 @@ public class TemplateUtilTest {
     @Test
     public void testIsToManyNonReadOnly() throws ClassNotFoundException, IOException {
         templateUtil.populateDataTypes("ClientCorporation", metaFieldSet, headers, dataTypes);
-        Assert.assertTrue(headers.contains("childClientCorporations.id"));
+        Assert.assertTrue(headers.contains("leads.id"));
     }
 
     @Test


### PR DESCRIPTION
Incorporated more read-only fields, which makes our template capability match our examples
as closely as possible.