### PR TITLE
Update And Delete Notes with ID

### DIFF
--- a/dataloader.properties
+++ b/dataloader.properties
@@ -49,7 +49,7 @@ loginUrl=https://rest.bullhornstaffing.com/rest-services/login
 #leadExistField=customText1
 #opportunityExistField=externalID
 #placementExistField=customText1
-noteExistField=id
+#noteExistField=id
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Section 4 -- Formatting

--- a/dataloader.properties
+++ b/dataloader.properties
@@ -49,6 +49,7 @@ loginUrl=https://rest.bullhornstaffing.com/rest-services/login
 #leadExistField=customText1
 #opportunityExistField=externalID
 #placementExistField=customText1
+noteExistField=id
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Section 4 -- Formatting

--- a/src/main/java/com/bullhorn/dataloader/task/AbstractTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/AbstractTask.java
@@ -143,6 +143,9 @@ public abstract class AbstractTask<A extends AssociationEntity, E extends Entity
     }
 
     protected <S extends SearchEntity> List<B> searchForEntity(String field, String value, Class fieldType, Class<B> entityClass, Set<String> fieldsToReturn) {
+        if(entityClass.equals(Note.class) && field.equals(StringConsts.ID)) {
+            field = StringConsts.NOTE_ID;
+        }
         String query = getQueryStatement(field, value, fieldType);
         fieldsToReturn = fieldsToReturn == null ? Sets.newHashSet("id") : fieldsToReturn;
         return (List<B>) bullhornData.search((Class<S>) entityClass, query, fieldsToReturn, ParamFactory.searchParams()).getData();

--- a/src/main/java/com/bullhorn/dataloader/task/DeleteTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/DeleteTask.java
@@ -90,11 +90,7 @@ public class DeleteTask<A extends AssociationEntity, E extends EntityAssociation
         existFieldsMap.put(StringConsts.ID, bullhornID.toString());
 
         if (EntityValidation.isSoftDeletable(entityInfo.getEntityName())) {
-            if(entityClass.equals(Note.class)) {
-                existFieldsMap.put(StringConsts.IS_DELETED, "false");
-            } else {
-                existFieldsMap.put(StringConsts.IS_DELETED, "0");
-            }
+            existFieldsMap.putAll(setIsDeleted(existFieldsMap));
             List<B> existingEntityList = findEntityList(existFieldsMap);
             return !existingEntityList.isEmpty();
         } else if (EntityValidation.isHardDeletable(entityInfo.getEntityName())) {
@@ -104,5 +100,14 @@ public class DeleteTask<A extends AssociationEntity, E extends EntityAssociation
             throw new RestApiException("Row " + rowNumber + ": Cannot Perform Delete: " + entityClass.getSimpleName() +
                 " records are not deletable.");
         }
+    }
+
+    private Map<String, String> setIsDeleted(Map<String, String> existFieldsMap) {
+        if(entityClass.equals(Note.class)) {
+            existFieldsMap.put(StringConsts.IS_DELETED, "false");
+        } else {
+            existFieldsMap.put(StringConsts.IS_DELETED, "0");
+        }
+        return existFieldsMap;
     }
 }

--- a/src/main/java/com/bullhorn/dataloader/task/DeleteTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/DeleteTask.java
@@ -12,6 +12,7 @@ import com.bullhorn.dataloader.util.validation.EntityValidation;
 import com.bullhornsdk.data.api.BullhornData;
 import com.bullhornsdk.data.exception.RestApiException;
 import com.bullhornsdk.data.model.entity.association.EntityAssociations;
+import com.bullhornsdk.data.model.entity.core.standard.Note;
 import com.bullhornsdk.data.model.entity.core.type.AssociationEntity;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.bullhornsdk.data.model.entity.core.type.DeleteEntity;
@@ -89,7 +90,11 @@ public class DeleteTask<A extends AssociationEntity, E extends EntityAssociation
         existFieldsMap.put(StringConsts.ID, bullhornID.toString());
 
         if (EntityValidation.isSoftDeletable(entityInfo.getEntityName())) {
-            existFieldsMap.put("isDeleted", "0");
+            if(entityClass.equals(Note.class)) {
+                existFieldsMap.put(StringConsts.IS_DELETED, "false");
+            } else {
+                existFieldsMap.put(StringConsts.IS_DELETED, "0");
+            }
             List<B> existingEntityList = findEntityList(existFieldsMap);
             return !existingEntityList.isEmpty();
         } else if (EntityValidation.isHardDeletable(entityInfo.getEntityName())) {

--- a/src/main/java/com/bullhorn/dataloader/task/DeleteTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/DeleteTask.java
@@ -90,7 +90,7 @@ public class DeleteTask<A extends AssociationEntity, E extends EntityAssociation
         existFieldsMap.put(StringConsts.ID, bullhornID.toString());
 
         if (EntityValidation.isSoftDeletable(entityInfo.getEntityName())) {
-            existFieldsMap.putAll(setIsDeleted(existFieldsMap));
+            existFieldsMap.putAll(getIsDeletedField());
             List<B> existingEntityList = findEntityList(existFieldsMap);
             return !existingEntityList.isEmpty();
         } else if (EntityValidation.isHardDeletable(entityInfo.getEntityName())) {
@@ -102,8 +102,9 @@ public class DeleteTask<A extends AssociationEntity, E extends EntityAssociation
         }
     }
 
-    private Map<String, String> setIsDeleted(Map<String, String> existFieldsMap) {
-        if(entityClass.equals(Note.class)) {
+    private Map<String, String> getIsDeletedField() {
+        Map<String, String> existFieldsMap = new HashMap<>();
+        if (entityClass.equals(Note.class)) {
             existFieldsMap.put(StringConsts.IS_DELETED, "false");
         } else {
             existFieldsMap.put(StringConsts.IS_DELETED, "0");

--- a/src/main/java/com/bullhorn/dataloader/task/LoadAttachmentTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/LoadAttachmentTask.java
@@ -96,7 +96,7 @@ public class LoadAttachmentTask<A extends AssociationEntity, E extends EntityAss
             for (String property : properties) {
                 String propertyValue = dataMap.get(getEntityAssociatedPropertyName(property));
                 Class fieldType = getFieldType(entityClass, WordUtils.uncapitalize(entityClass.getSimpleName()) + "ExistField", property);
-                propertiesWithValues.add(getQueryStatement(property, propertyValue, fieldType));
+                propertiesWithValues.add(getQueryStatement(property, propertyValue, fieldType, entityClass));
             }
             String query = Joiner.on(" AND ").join(propertiesWithValues);
             List<S> searchList = bullhornData.search((Class<S>) entityClass, query, Sets.newHashSet("id"), ParamFactory.searchParams()).getData();

--- a/src/main/java/com/bullhorn/dataloader/task/LoadTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/LoadTask.java
@@ -307,11 +307,22 @@ public class LoadTask<A extends AssociationEntity, E extends EntityAssociations,
     }
 
     protected void addNoteEntity(Note noteAdded, String targetEntityName, Integer targetEntityID) {
+        List<B> existingList = getNoteEntities(noteAdded, targetEntityName, targetEntityID);
+        if (!existingList.isEmpty()) {
+            return;
+        }
+
         NoteEntity noteEntity = new NoteEntity();
         noteEntity.setNote(noteAdded);
         noteEntity.setTargetEntityID(targetEntityID);
         noteEntity.setTargetEntityName(targetEntityName);
         bullhornData.insertEntity(noteEntity);
+    }
+
+    protected <Q extends QueryEntity> List<B> getNoteEntities(Note noteAdded, String targetEntityName, Integer targetEntityID) {
+        String where = "note.id=" + noteAdded.getId() + " AND targetEntityName='" + targetEntityName + "' AND targetEntityID=" + targetEntityID;
+        List<B> list = (List<B>) bullhornData.query((Class<Q>) NoteEntity.class, where, null, ParamFactory.queryParams()).getData();
+        return list;
     }
 
     protected List<Integer> getNewAssociationIdList(String field, AssociationField associationField) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {

--- a/src/main/java/com/bullhorn/dataloader/task/LoadTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/LoadTask.java
@@ -386,7 +386,7 @@ public class LoadTask<A extends AssociationEntity, E extends EntityAssociations,
 
     private String getQueryStatement(Set<String> valueSet, String field, Class<B> associationClass) {
         String fieldName = field.substring(field.indexOf(".") + 1, field.length());
-        return valueSet.stream().map(n -> getQueryStatement(fieldName, n, getFieldType(associationClass, field, fieldName))).collect(Collectors.joining(" OR "));
+        return valueSet.stream().map(n -> getQueryStatement(fieldName, n, getFieldType(associationClass, field, fieldName), associationClass)).collect(Collectors.joining(" OR "));
     }
 
     private String getWhereStatement(Set<String> valueSet, String field, Class<B> associationClass) {

--- a/src/main/java/com/bullhorn/dataloader/util/StringConsts.java
+++ b/src/main/java/com/bullhorn/dataloader/util/StringConsts.java
@@ -2,9 +2,6 @@ package com.bullhorn.dataloader.util;
 
 /**
  * Global String Constants
- * <p>
- * Only strings that are used in more than one class should go here. If a string constant is only used internal to a
- * class, that class should contain the string constant.
  */
 public class StringConsts {
     public static final String DESCRIPTION = "description";
@@ -17,6 +14,8 @@ public class StringConsts {
     public static final String TIMESTAMP = DateUtil.getTimestamp();
     public static final String TO_ONE = "TO_ONE";
     public static final String TO_MANY = "TO_MANY";
+    public static final String NOTE_ID = "noteID";
+    public static final String IS_DELETED = "isDeleted";
 
     private StringConsts() {}
 }

--- a/src/test/java/com/bullhorn/dataloader/integration/IntegrationTest.java
+++ b/src/test/java/com/bullhorn/dataloader/integration/IntegrationTest.java
@@ -103,13 +103,6 @@ public class IntegrationTest {
         TestUtils.checkResultsFiles(tempDirectory, Command.LOAD);
         // endregion
 
-        // region ~TEMPORARY_WORKAROUND~
-        // Notes cannot be updated or delete right now. https://jira.bullhorn.com/browse/BH-43594
-        // Taking out notes until the bug is fixed.
-        File noteExample = new File(tempDirPath + "/Note.csv");
-        noteExample.delete();
-        // endregion
-
         // region ~FIXME~
         // Updating of JobSubmission records is failing due to insufficient update privileges.
         File jobSubmissionExample = new File(tempDirPath + "/JobSubmission.csv");

--- a/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
@@ -10,7 +10,7 @@ import com.bullhorn.dataloader.util.PropertyFileUtil;
 import com.bullhornsdk.data.api.BullhornData;
 import com.bullhornsdk.data.model.entity.core.standard.*;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
-import com.bullhornsdk.data.model.enums.ChangeType;
+import com.bullhornsdk.data.model.enums.*;
 import com.bullhornsdk.data.model.response.crud.DeleteResponse;
 import com.bullhornsdk.data.model.response.crud.Message;
 import com.bullhornsdk.data.model.response.list.CandidateListWrapper;
@@ -213,6 +213,16 @@ public class DeleteTaskTest {
         Assert.assertEquals("false", task.getBooleanWhereStatement(zeroString));
         Assert.assertEquals("true", task.getBooleanWhereStatement(oneString));
         Assert.assertEquals("false", task.getBooleanWhereStatement(twoString));
+    }
+
+    @Test
+    public void testGetFieldEntityClassWithAssociation() {
+        final String candidateID = "candidate.id";
+
+        task = new DeleteTask(Command.DELETE, 1, EntityInfo.CANDIDATE, dataMap, csvFileWriterMock, propertyFileUtilMock, bullhornDataMock, printUtilMock, actionTotalsMock);
+        Class<BullhornEntityInfo> bullhornEntityInfo = task.getFieldEntityClass(candidateID);
+
+        Assert.assertEquals(bullhornEntityInfo.getSimpleName(), EntityInfo.CANDIDATE.getEntityName());
     }
 
     public <B extends BullhornEntity> ListWrapper<B> getListWrapper(Class<B> entityClass) throws IllegalAccessException, InstantiationException {

--- a/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
@@ -95,10 +95,11 @@ public class DeleteTaskTest {
     public void run_Success_Note() throws IOException, InstantiationException, IllegalAccessException {
         final String[] expectedValues = {"1"};
         task = new DeleteTask(Command.DELETE, 1, EntityInfo.NOTE, dataMap, csvFileWriterMock, propertyFileUtilMock, bullhornDataMock, printUtilMock, actionTotalsMock);
-        when(bullhornDataMock.search(eq(Note.class), eq("isDeleted:false AND id:1"), any(), any())).thenReturn(getListWrapper(Note.class));
+        when(bullhornDataMock.search(eq(Note.class), eq("isDeleted:false AND noteID:1"), any(), any())).thenReturn(getListWrapper(Note.class));
         when(bullhornDataMock.deleteEntity(any(), anyInt())).thenReturn(new DeleteResponse());
         Result expectedResult = new Result(Result.Status.SUCCESS, Result.Action.DELETE, 1, "");
 
+        task.init();
         task.run();
 
         verify(csvFileWriterMock).writeRow(eq(expectedValues), resultArgumentCaptor.capture());

--- a/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
@@ -8,9 +8,7 @@ import com.bullhorn.dataloader.util.ActionTotals;
 import com.bullhorn.dataloader.util.PrintUtil;
 import com.bullhorn.dataloader.util.PropertyFileUtil;
 import com.bullhornsdk.data.api.BullhornData;
-import com.bullhornsdk.data.model.entity.core.standard.Appointment;
-import com.bullhornsdk.data.model.entity.core.standard.Candidate;
-import com.bullhornsdk.data.model.entity.core.standard.Placement;
+import com.bullhornsdk.data.model.entity.core.standard.*;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.bullhornsdk.data.model.enums.ChangeType;
 import com.bullhornsdk.data.model.response.crud.DeleteResponse;
@@ -83,6 +81,21 @@ public class DeleteTaskTest {
         final String[] expectedValues = {"1"};
         task = new DeleteTask(Command.DELETE, 1, EntityInfo.APPOINTMENT, dataMap, csvFileWriterMock, propertyFileUtilMock, bullhornDataMock, printUtilMock, actionTotalsMock);
         when(bullhornDataMock.query(eq(Appointment.class), eq("isDeleted=false AND id=1"), any(), any())).thenReturn(getListWrapper(Appointment.class));
+        when(bullhornDataMock.deleteEntity(any(), anyInt())).thenReturn(new DeleteResponse());
+        Result expectedResult = new Result(Result.Status.SUCCESS, Result.Action.DELETE, 1, "");
+
+        task.run();
+
+        verify(csvFileWriterMock).writeRow(eq(expectedValues), resultArgumentCaptor.capture());
+        final Result actualResult = resultArgumentCaptor.getValue();
+        Assert.assertThat(actualResult, new ReflectionEquals(expectedResult));
+    }
+
+    @Test
+    public void run_Success_Note() throws IOException, InstantiationException, IllegalAccessException {
+        final String[] expectedValues = {"1"};
+        task = new DeleteTask(Command.DELETE, 1, EntityInfo.NOTE, dataMap, csvFileWriterMock, propertyFileUtilMock, bullhornDataMock, printUtilMock, actionTotalsMock);
+        when(bullhornDataMock.search(eq(Note.class), eq("isDeleted:false AND id:1"), any(), any())).thenReturn(getListWrapper(Note.class));
         when(bullhornDataMock.deleteEntity(any(), anyInt())).thenReturn(new DeleteResponse());
         Result expectedResult = new Result(Result.Status.SUCCESS, Result.Action.DELETE, 1, "");
 

--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -335,7 +335,6 @@ public class LoadTaskTest {
         dataMap.clear();
         dataMap.put("candidates.id", "1;2");
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, EntityInfo.NOTE, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateID, bullhornDataMock, printUtilMock, actionTotalsMock));
-        when(task.getAttachmentFilePath("Candidate", "11")).thenReturn("src/test/resources/convertedAttachments/Candidate/11.html");
         Mockito.doReturn(Optional.ofNullable(null)).when(propertyFileUtilMock_CandidateID).getEntityExistFields("Note");
 
         final List<Candidate> candidates = new ArrayList<>();
@@ -349,6 +348,7 @@ public class LoadTaskTest {
         response.setChangedEntityId(1);
         when(bullhornDataMock.insertEntity(any())).thenReturn(response);
 
+        task.init();
         task.run();
 
         verify(csvFileWriterMock).writeRow(any(), resultArgumentCaptor.capture());
@@ -756,13 +756,14 @@ public class LoadTaskTest {
         candidateListWrapper.setData(candidateList);
         when(bullhornDataMock.search(any(), any(), any(), any())).thenReturn(candidateListWrapper);
 
+        task.init();
         task.findEntity("clientCorporation.id", "clientCorporation", ClientCorporation.class, Integer.class);
 
         verify(bullhornDataMock, times(1)).search(any(), any(), any(), any());
     }
 
     @Test
-    public void findEntityNoteTest_search() {
+    public void findEntityTest_note() {
         dataMap = new LinkedHashMap<>();
         dataMap.put("id", "1");
         methodMap.clear();
@@ -774,9 +775,10 @@ public class LoadTaskTest {
         List<Note> noteList = new ArrayList<>();
         noteList.add(new Note(1));
         noteListWrapper.setData(noteList);
-        when(bullhornDataMock.search(any(), any(), any(), any())).thenReturn(noteListWrapper);
+        when(bullhornDataMock.search(eq(Note.class), eq("noteID:1"), any(), any())).thenReturn(noteListWrapper);
 
-        task.findEntity("note.id", "id", Note.class, Integer.class);
+        task.init();
+        task.findEntity("id", "id", Note.class, Integer.class);
 
         verify(bullhornDataMock, times(1)).search(any(), any(), any(), any());
     }
@@ -792,6 +794,7 @@ public class LoadTaskTest {
         candidateListWrapper.setData(new ArrayList<>());
         when(bullhornDataMock.search(any(), any(), any(), any())).thenReturn(candidateListWrapper);
 
+        task.init();
         task.findEntity("clientCorporation.id", "clientCorporation", ClientCorporation.class, Integer.class);
     }
 
@@ -807,6 +810,7 @@ public class LoadTaskTest {
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, EntityInfo.CLIENT_CONTACT, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
         when(bullhornDataMock.search(any(), any(), any(), any())).thenReturn(candidateListWrapper);
 
+        task.init();
         task.findEntity("clientCorporation.id", "clientCorporation", ClientCorporation.class, Integer.class);
 
         verify(bullhornDataMock, times(1)).search(any(), any(), any(), any());
@@ -832,7 +836,8 @@ public class LoadTaskTest {
     public void getQueryStatement_unsupportedType() {
         task = Mockito.spy(new LoadTask(Command.LOAD, 1, EntityInfo.CANDIDATE, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateExternalID, bullhornDataMock, printUtilMock, actionTotalsMock));
 
-        task.getQueryStatement("comments", "my comment", double.class);
+        task.init();
+        task.getQueryStatement("doubleField", "doubleValue", double.class, Note.class);
     }
 
     @Test

--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -309,6 +309,10 @@ public class LoadTaskTest {
         placementListWrapper.setData(placements);
         when(bullhornDataMock.search(eq(Placement.class), eq("customText1:\"7\""), any(), any())).thenReturn(placementListWrapper);
 
+        // Do not mock out any existing note entities
+        final ListWrapper<NoteEntity> noteEntityListWrapper = new NoteEntityListWrapper();
+        when(bullhornDataMock.query(eq(NoteEntity.class), any(), any(), any())).thenReturn(noteEntityListWrapper);
+
         CreateResponse response = new CreateResponse();
         response.setChangedEntityId(1);
         when(bullhornDataMock.insertEntity(any())).thenReturn(response);
@@ -382,6 +386,106 @@ public class LoadTaskTest {
         final Result actualResult = resultArgumentCaptor.getValue();
         Assert.assertThat(expectedResult, new ReflectionEquals(actualResult));
 
+
+        Mockito.verify(actionTotalsMock, never()).incrementActionTotal(Result.Action.INSERT);
+        Mockito.verify(actionTotalsMock, Mockito.times(1)).incrementActionTotal(Result.Action.UPDATE);
+        Mockito.verify(actionTotalsMock, never()).incrementActionTotal(Result.Action.CONVERT);
+        Mockito.verify(actionTotalsMock, never()).incrementActionTotal(Result.Action.DELETE);
+        Mockito.verify(actionTotalsMock, never()).incrementActionTotal(Result.Action.FAILURE);
+        Mockito.verify(actionTotalsMock, never()).incrementActionTotal(Result.Action.NOT_SET);
+    }
+
+    @Test
+    public void run_UpdateSuccess_Note() throws IOException, InstantiationException, IllegalAccessException {
+        Result expectedResult = new Result(Result.Status.SUCCESS, Result.Action.UPDATE, 1, "");
+
+        dataMap.clear();
+        dataMap.put("id", "1");
+        dataMap.put("candidates.externalID", "1;2");
+        dataMap.put("clientContacts.externalID", "3");
+        dataMap.put("leads.customText1", "4");
+        dataMap.put("jobOrders.externalID", "5");
+        dataMap.put("opportunities.externalID", "6");
+        dataMap.put("placements.customText1", "7");
+
+        methodMap = concurrencyService.createMethodMap(Note.class);
+        task = Mockito.spy(new LoadTask(Command.LOAD, 1, EntityInfo.NOTE, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_CandidateID, bullhornDataMock, printUtilMock, actionTotalsMock));
+
+        List<String> idExistField = Arrays.asList(new String[]{"id"});
+        Mockito.doReturn(Optional.ofNullable(idExistField)).when(propertyFileUtilMock_CandidateID).getEntityExistFields("Note");
+        when(bullhornDataMock.search(eq(Note.class), eq("noteID:1"), any(), any())).thenReturn(getListWrapper(Note.class));
+
+        final List<Candidate> candidates = new ArrayList<>();
+        Candidate candidate1 = new Candidate(1001);
+        candidate1.setExternalID("1");
+        candidates.add(candidate1);
+        Candidate candidate2 = new Candidate(1002);
+        candidate2.setExternalID("2");
+        candidates.add(candidate2);
+        final ListWrapper<Candidate> candidateListWrapper = new CandidateListWrapper();
+        candidateListWrapper.setData(candidates);
+        when(bullhornDataMock.search(eq(Candidate.class), eq("externalID:\"1\" OR externalID:\"2\""), any(), any())).thenReturn(candidateListWrapper);
+
+        final List<ClientContact> clientContacts = new ArrayList<>();
+        ClientContact clientContact = new ClientContact(1003);
+        clientContact.setExternalID("3");
+        clientContacts.add(clientContact);
+        final ListWrapper<ClientContact> clientContactListWrapper = new ClientContactListWrapper();
+        clientContactListWrapper.setData(clientContacts);
+        when(bullhornDataMock.search(eq(ClientContact.class), eq("externalID:\"3\""), any(), any())).thenReturn(clientContactListWrapper);
+
+        final List<Lead> leads = new ArrayList<>();
+        Lead lead = new Lead(1004);
+        lead.setCustomText1("4");
+        leads.add(lead);
+        final ListWrapper<Lead> leadListWrapper = new LeadListWrapper();
+        leadListWrapper.setData(leads);
+        when(bullhornDataMock.search(eq(Lead.class), eq("customText1:\"4\""), any(), any())).thenReturn(leadListWrapper);
+
+        final List<JobOrder> jobOrders = new ArrayList<>();
+        JobOrder jobOrder = new JobOrder(1005);
+        jobOrder.setExternalID("5");
+        jobOrders.add(jobOrder);
+        final ListWrapper<JobOrder> jobOrderListWrapper = new JobOrderListWrapper();
+        jobOrderListWrapper.setData(jobOrders);
+        when(bullhornDataMock.search(eq(JobOrder.class), eq("externalID:\"5\""), any(), any())).thenReturn(jobOrderListWrapper);
+
+        final List<Opportunity> opportunities = new ArrayList<>();
+        Opportunity opportunity = new Opportunity(1006);
+        opportunity.setExternalID("6");
+        opportunities.add(opportunity);
+        final ListWrapper<Opportunity> opportunityListWrapper = new OpportunityListWrapper();
+        opportunityListWrapper.setData(opportunities);
+        when(bullhornDataMock.search(eq(Opportunity.class), eq("externalID:\"6\""), any(), any())).thenReturn(opportunityListWrapper);
+
+        final List<Placement> placements = new ArrayList<>();
+        Placement placement = new Placement(1007);
+        placement.setCustomText1("7");
+        placements.add(placement);
+        final ListWrapper<Placement> placementListWrapper = new PlacementListWrapper();
+        placementListWrapper.setData(placements);
+        when(bullhornDataMock.search(eq(Placement.class), eq("customText1:\"7\""), any(), any())).thenReturn(placementListWrapper);
+
+        // Mock out existing note entities
+        final ListWrapper<NoteEntity> noteEntityListWrapper = new NoteEntityListWrapper();
+        List<NoteEntity> noteEntityList = new ArrayList<>();
+        noteEntityList.add(new NoteEntity());
+        noteEntityListWrapper.setData(noteEntityList);
+        when(bullhornDataMock.query(eq(NoteEntity.class), any(), any(), any())).thenReturn(noteEntityListWrapper);
+
+        UpdateResponse response = new UpdateResponse();
+        response.setChangedEntityId(1);
+        when(bullhornDataMock.updateEntity(any())).thenReturn(response);
+
+        task.init();
+        task.run();
+
+        verify(csvFileWriterMock).writeRow(any(), resultArgumentCaptor.capture());
+        final Result actualResult = resultArgumentCaptor.getValue();
+        Assert.assertThat(actualResult, new ReflectionEquals(expectedResult));
+
+        Mockito.verify(bullhornDataMock, Mockito.never()).insertEntity(any());
+        Mockito.verify(bullhornDataMock, Mockito.times(1)).updateEntity(any());
 
         Mockito.verify(actionTotalsMock, never()).incrementActionTotal(Result.Action.INSERT);
         Mockito.verify(actionTotalsMock, Mockito.times(1)).incrementActionTotal(Result.Action.UPDATE);

--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -11,28 +11,11 @@ import com.bullhorn.dataloader.util.PropertyFileUtil;
 import com.bullhornsdk.data.api.BullhornData;
 import com.bullhornsdk.data.exception.RestApiException;
 import com.bullhornsdk.data.model.entity.association.standard.CandidateAssociations;
-import com.bullhornsdk.data.model.entity.core.standard.Candidate;
-import com.bullhornsdk.data.model.entity.core.standard.CandidateEducation;
-import com.bullhornsdk.data.model.entity.core.standard.ClientContact;
-import com.bullhornsdk.data.model.entity.core.standard.ClientCorporation;
-import com.bullhornsdk.data.model.entity.core.standard.CorporateUser;
-import com.bullhornsdk.data.model.entity.core.standard.JobOrder;
-import com.bullhornsdk.data.model.entity.core.standard.Lead;
-import com.bullhornsdk.data.model.entity.core.standard.Opportunity;
-import com.bullhornsdk.data.model.entity.core.standard.Placement;
-import com.bullhornsdk.data.model.entity.core.standard.Skill;
+import com.bullhornsdk.data.model.entity.core.standard.*;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.bullhornsdk.data.model.response.crud.CreateResponse;
 import com.bullhornsdk.data.model.response.crud.UpdateResponse;
-import com.bullhornsdk.data.model.response.list.CandidateListWrapper;
-import com.bullhornsdk.data.model.response.list.ClientContactListWrapper;
-import com.bullhornsdk.data.model.response.list.JobOrderListWrapper;
-import com.bullhornsdk.data.model.response.list.LeadListWrapper;
-import com.bullhornsdk.data.model.response.list.ListWrapper;
-import com.bullhornsdk.data.model.response.list.OpportunityListWrapper;
-import com.bullhornsdk.data.model.response.list.PlacementListWrapper;
-import com.bullhornsdk.data.model.response.list.SkillListWrapper;
-import com.bullhornsdk.data.model.response.list.StandardListWrapper;
+import com.bullhornsdk.data.model.response.list.*;
 import com.csvreader.CsvReader;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -75,6 +58,7 @@ public class LoadTaskTest {
     private BullhornData bullhornDataMock;
     private PropertyFileUtil propertyFileUtilMock_CandidateID;
     private PropertyFileUtil propertyFileUtilMock_CandidateExternalID;
+    private PropertyFileUtil propertyFileUtilMock_NoteID;
 
     private LinkedHashMap<String, String> dataMap;
     private Map<String, Method> methodMap;
@@ -95,6 +79,7 @@ public class LoadTaskTest {
         printUtilMock = Mockito.mock(PrintUtil.class);
         propertyFileUtilMock_CandidateID = Mockito.mock(PropertyFileUtil.class);
         propertyFileUtilMock_CandidateExternalID = Mockito.mock(PropertyFileUtil.class);
+        propertyFileUtilMock_NoteID = Mockito.mock(PropertyFileUtil.class);
 
         List<String> idExistField = Arrays.asList(new String[]{"id"});
         Mockito.doReturn(Optional.ofNullable(idExistField)).when(propertyFileUtilMock_CandidateID).getEntityExistFields("Candidate");
@@ -775,6 +760,27 @@ public class LoadTaskTest {
 
         verify(bullhornDataMock, times(1)).search(any(), any(), any(), any());
     }
+
+    @Test
+    public void findEntityNoteTest_search() {
+        dataMap = new LinkedHashMap<>();
+        dataMap.put("id", "1");
+        methodMap.clear();
+        methodMap = concurrencyService.createMethodMap(Note.class);
+
+        task = Mockito.spy(new LoadTask(Command.LOAD, 1, EntityInfo.NOTE, dataMap, methodMap, countryNameToIdMap, csvFileWriterMock, propertyFileUtilMock_NoteID, bullhornDataMock, printUtilMock, actionTotalsMock));
+
+        NoteListWrapper noteListWrapper = new NoteListWrapper();
+        List<Note> noteList = new ArrayList<>();
+        noteList.add(new Note(1));
+        noteListWrapper.setData(noteList);
+        when(bullhornDataMock.search(any(), any(), any(), any())).thenReturn(noteListWrapper);
+
+        task.findEntity("note.id", "id", Note.class, Integer.class);
+
+        verify(bullhornDataMock, times(1)).search(any(), any(), any(), any());
+    }
+
 
     @Test(expected = RestApiException.class)
     public void findEntityTest_searchReturnsEmptyList() {


### PR DESCRIPTION
Notes can now update and delete successfully by using the ID field on notes (requires changing the search where clause to "noteID". Also, in updating, a duplicate check must be made for NoteEntity to avoid REST errors.