### PR TITLE
Fix for critical bug where fileContent can never be updated

### DIFF
--- a/src/main/java/com/bullhorn/dataloader/task/LoadAttachmentTask.java
+++ b/src/main/java/com/bullhorn/dataloader/task/LoadAttachmentTask.java
@@ -134,7 +134,7 @@ public class LoadAttachmentTask<A extends AssociationEntity, E extends EntityAss
             throw new IOException("Row " + rowNumber + ": Missing the '" + StringConsts.RELATIVE_FILE_PATH + "' column required for loadAttachments");
         }
 
-        if (isNewEntity || dataMap.contains(StringConsts.RELATIVE_FILE_PATH)) {
+        if (isNewEntity || dataMap.containsKey(StringConsts.RELATIVE_FILE_PATH)) {
             try {
                 byte[] encoded = Files.readAllBytes(Paths.get(dataMap.get(StringConsts.RELATIVE_FILE_PATH)));
                 String fileStr = StringUtils.newStringUtf8(org.apache.commons.codec.binary.Base64.encodeBase64(encoded));


### PR DESCRIPTION
Contents of the file to be loaded was only being read when uploading new files, and never on updates.