### PR TITLE
feat(Single Byte Encoding): New option for using single byte encoding

### DIFF
--- a/dataloader.properties
+++ b/dataloader.properties
@@ -148,10 +148,16 @@ loginUrl=https://rest.bullhornstaffing.com/rest-services/login
 # processEmptyAssociations -- If set to true then all To-Many association cells that are empty will remove any
 #                             existing associations. Default value is false, which will ignore the empty cells.
 #
+# singleByteEncoding -- If set to true then CSV files will be read in using the ISO-8859-1 (single-byte) encoding.
+#                       If set to false then CVS files will be read in using the UTF-8 (multi-byte) encoding.
+#                       The single byte encoding covers only latin characters and some accented characters while
+#                       UTF-8 covers all characters from all languages.
+#
 # ---------------------------------------------------------------------------------------------------------------------
 listDelimiter=;
 dateFormat=MM/dd/yy HH:mm
 processEmptyAssociations=false
+singleByteEncoding=false
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Section 5 -- Performance

--- a/src/main/java/com/bullhorn/dataloader/data/CsvFileReader.java
+++ b/src/main/java/com/bullhorn/dataloader/data/CsvFileReader.java
@@ -1,5 +1,6 @@
 package com.bullhorn.dataloader.data;
 
+import com.bullhorn.dataloader.util.PropertyFileUtil;
 import com.csvreader.CsvReader;
 import com.google.common.collect.Sets;
 
@@ -23,8 +24,8 @@ public class CsvFileReader extends CsvReader {
      *
      * @param filePath the path to the CSV file
      */
-    public CsvFileReader(String filePath) throws IOException {
-        super(filePath, ',', Charset.forName("UTF-8"));
+    public CsvFileReader(String filePath, PropertyFileUtil propertyFileUtil) throws IOException {
+        super(filePath, ',', propertyFileUtil.getSingleByteEncoding() ? Charset.forName("ISO-8859-1") : Charset.forName("UTF-8"));
         // Turn the SafetySwitch off because it limits the maximum length of any column to 100,000 characters
         setSafetySwitch(false);
         readHeaders();

--- a/src/main/java/com/bullhorn/dataloader/enums/Property.java
+++ b/src/main/java/com/bullhorn/dataloader/enums/Property.java
@@ -19,6 +19,7 @@ public enum Property {
     RESULTS_FILE_ENABLED("resultsFileEnabled"),
     RESULTS_FILE_PATH("resultsFilePath"),
     RESULTS_FILE_WRITE_INTERVAL_MSEC("resultsFileWriteIntervalMsec"),
+    SINGLE_BYTE_ENCODING("singleByteEncoding"),
     TOKEN_URL("tokenUrl"),
     USERNAME("username"),
     VERBOSE("verbose"),

--- a/src/main/java/com/bullhorn/dataloader/service/ProcessRunner.java
+++ b/src/main/java/com/bullhorn/dataloader/service/ProcessRunner.java
@@ -58,7 +58,7 @@ public class ProcessRunner {
     ActionTotals runLoadProcess(EntityInfo entityInfo, String filePath) throws IOException, InterruptedException {
         RestApi restApi = restSession.getRestApi();
         ExecutorService executorService = threadPoolUtil.getExecutorService();
-        CsvFileReader csvFileReader = new CsvFileReader(filePath);
+        CsvFileReader csvFileReader = new CsvFileReader(filePath, propertyFileUtil);
         CsvFileWriter csvFileWriter = new CsvFileWriter(Command.LOAD, filePath, csvFileReader.getHeaders());
         ActionTotals actionTotals = new ActionTotals();
 
@@ -83,7 +83,7 @@ public class ProcessRunner {
     ActionTotals runDeleteProcess(EntityInfo entityInfo, String filePath) throws IOException, InterruptedException {
         RestApi restApi = restSession.getRestApi();
         ExecutorService executorService = threadPoolUtil.getExecutorService();
-        CsvFileReader csvFileReader = new CsvFileReader(filePath);
+        CsvFileReader csvFileReader = new CsvFileReader(filePath, propertyFileUtil);
         CsvFileWriter csvFileWriter = new CsvFileWriter(Command.DELETE, filePath, csvFileReader.getHeaders());
         ActionTotals actionTotals = new ActionTotals();
 
@@ -108,7 +108,7 @@ public class ProcessRunner {
     ActionTotals runLoadAttachmentsProcess(EntityInfo entityInfo, String filePath) throws IOException, InterruptedException {
         RestApi restApi = restSession.getRestApi();
         ExecutorService executorService = threadPoolUtil.getExecutorService();
-        CsvFileReader csvFileReader = new CsvFileReader(filePath);
+        CsvFileReader csvFileReader = new CsvFileReader(filePath, propertyFileUtil);
         CsvFileWriter csvFileWriter = new CsvFileWriter(Command.LOAD_ATTACHMENTS, filePath, csvFileReader.getHeaders());
         ActionTotals actionTotals = new ActionTotals();
 
@@ -133,7 +133,7 @@ public class ProcessRunner {
     ActionTotals runConvertAttachmentsProcess(EntityInfo entityInfo, String filePath) throws IOException, InterruptedException {
         RestApi restApi = restSession.getRestApi();
         ExecutorService executorService = threadPoolUtil.getExecutorService();
-        CsvFileReader csvFileReader = new CsvFileReader(filePath);
+        CsvFileReader csvFileReader = new CsvFileReader(filePath, propertyFileUtil);
         CsvFileWriter csvFileWriter = new CsvFileWriter(Command.CONVERT_ATTACHMENTS, filePath, csvFileReader.getHeaders());
         ActionTotals actionTotals = new ActionTotals();
 
@@ -158,7 +158,7 @@ public class ProcessRunner {
     ActionTotals runDeleteAttachmentsProcess(EntityInfo entityInfo, String filePath) throws IOException, InterruptedException {
         RestApi restApi = restSession.getRestApi();
         ExecutorService executorService = threadPoolUtil.getExecutorService();
-        CsvFileReader csvFileReader = new CsvFileReader(filePath);
+        CsvFileReader csvFileReader = new CsvFileReader(filePath, propertyFileUtil);
         CsvFileWriter csvFileWriter = new CsvFileWriter(Command.CONVERT_ATTACHMENTS, filePath, csvFileReader.getHeaders());
         ActionTotals actionTotals = new ActionTotals();
 

--- a/src/main/java/com/bullhorn/dataloader/util/PropertyFileUtil.java
+++ b/src/main/java/com/bullhorn/dataloader/util/PropertyFileUtil.java
@@ -43,6 +43,7 @@ public class PropertyFileUtil {
     private Integer numThreads;
     private Integer waitSecondsBetweenFilesInDirectory;
     private Boolean processEmptyAssociations;
+    private Boolean singleByteEncoding;
     private Boolean resultsFileEnabled;
     private String resultsFilePath;
     private Integer resultsFileWriteIntervalMsec;
@@ -169,6 +170,10 @@ public class PropertyFileUtil {
 
     public Boolean getProcessEmptyAssociations() {
         return processEmptyAssociations;
+    }
+
+    public Boolean getSingleByteEncoding() {
+        return singleByteEncoding;
     }
 
     public Boolean getResultsFileEnabled() {
@@ -317,6 +322,8 @@ public class PropertyFileUtil {
             Property.WAIT_SECONDS_BETWEEN_FILES_IN_DIRECTORY.getName()));
         processEmptyAssociations = propertyValidationUtil.validateBooleanProperty(
             Boolean.valueOf(properties.getProperty(Property.PROCESS_EMPTY_ASSOCIATIONS.getName())));
+        singleByteEncoding = propertyValidationUtil.validateBooleanProperty(
+            Boolean.valueOf(properties.getProperty(Property.SINGLE_BYTE_ENCODING.getName())));
         resultsFileEnabled = propertyValidationUtil.validateBooleanProperty(
             Boolean.valueOf(properties.getProperty(Property.RESULTS_FILE_ENABLED.getName())));
         resultsFilePath = propertyValidationUtil.validateResultsFilePath(

--- a/src/test/java/com/bullhorn/dataloader/data/CsvFileReaderTest.java
+++ b/src/test/java/com/bullhorn/dataloader/data/CsvFileReaderTest.java
@@ -1,21 +1,26 @@
 package com.bullhorn.dataloader.data;
 
 import com.bullhorn.dataloader.TestUtils;
+import com.bullhorn.dataloader.util.PropertyFileUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.mockito.Mockito.mock;
+
 public class CsvFileReaderTest {
 
+    private PropertyFileUtil propertyFileUtilMock = mock(PropertyFileUtil.class);
+
     @Test
-    public void duplicateHeaders() throws IOException, InterruptedException {
+    public void duplicateHeaders() throws IOException {
         IllegalStateException expectedException = new IllegalStateException("Provided CSV file contains the following duplicate headers:\n"
             + "\tname\n");
 
         IllegalStateException actualException = null;
         try {
-            new CsvFileReader(TestUtils.getResourceFilePath("ClientCorporation_DuplicateColumns.csv"));
+            new CsvFileReader(TestUtils.getResourceFilePath("ClientCorporation_DuplicateColumns.csv"), propertyFileUtilMock);
         } catch (IllegalStateException e) {
             actualException = e;
         }
@@ -27,7 +32,7 @@ public class CsvFileReaderTest {
     @Test
     public void missingHeader() throws IOException, InterruptedException {
         IOException expectedException = new IOException("Header column count 2 is not equal to row column count 3");
-        CsvFileReader csvFileReader = new CsvFileReader(TestUtils.getResourceFilePath("ClientCorporation_MissingHeader.csv"));
+        CsvFileReader csvFileReader = new CsvFileReader(TestUtils.getResourceFilePath("ClientCorporation_MissingHeader.csv"), propertyFileUtilMock);
 
         IOException actualException = null;
         try {

--- a/src/test/java/com/bullhorn/dataloader/util/PropertyFileUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/PropertyFileUtilTest.java
@@ -73,6 +73,7 @@ public class PropertyFileUtilTest {
         Assert.assertEquals(";", propertyFileUtil.getListDelimiter());
         Assert.assertEquals(DateTimeFormat.forPattern("MM/dd/yyyy HH:mm:ss.SSS"), propertyFileUtil.getDateParser());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getProcessEmptyAssociations());
+        Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getSingleByteEncoding());
         Assert.assertEquals(new Integer(10), propertyFileUtil.getNumThreads());
         Assert.assertEquals(new Integer(0), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getVerbose());
@@ -89,6 +90,7 @@ public class PropertyFileUtilTest {
         envVars.put("DATALOADER_LOGIN_URL", "https://rest.bullhornstaffing.com/rest-services/cherry");
         envVars.put("DATALOADER_LIST_DELIMITER", ",");
         envVars.put("DATALOADER_PROCESS_EMPTY_ASSOCIATIONS", "true");
+        envVars.put("DATALOADER_SINGLE_BYTE_ENCODING", "TRUE");
         envVars.put("DATALOADER_NUM_THREADS", "5");
         envVars.put("DATALOADER_WAIT_SECONDS_BETWEEN_FILES_IN_DIRECTORY", "15");
         envVars.put("DATALOADER_VERBOSE", "FALSE");
@@ -122,6 +124,7 @@ public class PropertyFileUtilTest {
         Assert.assertEquals(",", propertyFileUtil.getListDelimiter());
         Assert.assertEquals(DateTimeFormat.forPattern("MM/dd/yyyy HH:mm:ss.SSS"), propertyFileUtil.getDateParser());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getProcessEmptyAssociations());
+        Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getSingleByteEncoding());
         Assert.assertEquals(new Integer(5), propertyFileUtil.getNumThreads());
         Assert.assertEquals(new Integer(15), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getVerbose());
@@ -138,6 +141,7 @@ public class PropertyFileUtilTest {
         envVars.put("DATALOADER_LOGIN_URL", "https://rest.bullhornstaffing.com/rest-services/cherry");
         envVars.put("DATALOADER_LIST_DELIMITER", ",");
         envVars.put("DATALOADER_PROCESS_EMPTY_ASSOCIATIONS", "false");
+        envVars.put("DATALOADER_SINGLE_BYTE_ENCODING", "TRUE");
         envVars.put("DATALOADER_NUM_THREADS", "5");
         envVars.put("DATALOADER_WAIT_SECONDS_BETWEEN_FILES_IN_DIRECTORY", "15");
         envVars.put("DATALOADER_VERBOSE", "FALSE");
@@ -151,6 +155,7 @@ public class PropertyFileUtilTest {
         systemProperties.setProperty("loginUrl", "https://rest.bullhornstaffing.com/rest-services/wallaby");
         systemProperties.setProperty("listDelimiter", "|");
         systemProperties.setProperty("processEmptyAssociations", "true");
+        systemProperties.setProperty("singleByteEncoding", "false");
         systemProperties.setProperty("numThreads", "6");
         systemProperties.setProperty("waitSecondsBetweenFilesInDirectory", "20");
         systemProperties.setProperty("verbose", "false");
@@ -168,6 +173,7 @@ public class PropertyFileUtilTest {
         Assert.assertEquals("|", propertyFileUtil.getListDelimiter());
         Assert.assertEquals(DateTimeFormat.forPattern("MM/dd/yyyy HH:mm:ss.SSS"), propertyFileUtil.getDateParser());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getProcessEmptyAssociations());
+        Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getSingleByteEncoding());
         Assert.assertEquals(new Integer(6), propertyFileUtil.getNumThreads());
         Assert.assertEquals(new Integer(20), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getResultsFileEnabled());
@@ -187,6 +193,7 @@ public class PropertyFileUtilTest {
         envVars.put("DATALOADER_LOGIN_URL", "https://rest.bullhornstaffing.com/rest-services/cherry");
         envVars.put("DATALOADER_LIST_DELIMITER", ",");
         envVars.put("DATALOADER_PROCESS_EMPTY_ASSOCIATIONS", "false");
+        envVars.put("DATALOADER_SINGLE_BYTE_ENCODING", "TRUE");
         envVars.put("DATALOADER_NUM_THREADS", "5");
         envVars.put("DATALOADER_WAIT_SECONDS_BETWEEN_FILES_IN_DIRECTORY", "15");
         envVars.put("DATALOADER_VERBOSE", "FALSE");
@@ -200,6 +207,7 @@ public class PropertyFileUtilTest {
         systemProperties.setProperty("loginUrl", "https://rest.bullhornstaffing.com/rest-services/wallaby");
         systemProperties.setProperty("listDelimiter", "|");
         systemProperties.setProperty("processEmptyAssociations", "true");
+        systemProperties.setProperty("singleByteEncoding", "false");
         systemProperties.setProperty("numThreads", "6");
         systemProperties.setProperty("waitSecondsBetweenFilesInDirectory", "20");
         systemProperties.setProperty("verbose", "false");
@@ -223,6 +231,8 @@ public class PropertyFileUtilTest {
         args.add("&");
         args.add("processEmptyAssociations");
         args.add("false");
+        args.add("singleByteEncoding");
+        args.add("true");
         args.add("-NUM_THREADS");
         args.add("7");
         args.add("-waitSecondsBetweenFilesInDirectory");
@@ -249,6 +259,7 @@ public class PropertyFileUtilTest {
         Assert.assertEquals("&", propertyFileUtil.getListDelimiter());
         Assert.assertEquals(DateTimeFormat.forPattern("MM/dd/yyyy HH:mm:ss.SSS"), propertyFileUtil.getDateParser());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getProcessEmptyAssociations());
+        Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getSingleByteEncoding());
         Assert.assertEquals(new Integer(7), propertyFileUtil.getNumThreads());
         Assert.assertEquals(new Integer(25), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getResultsFileEnabled());

--- a/src/test/resources/integrationTest/integrationTest.properties
+++ b/src/test/resources/integrationTest/integrationTest.properties
@@ -102,6 +102,8 @@ placementCustomObjectInstance10ExistField=placement.customText1,text1
 # ---------------------------------------------------------------------------------------------------------------------
 listDelimiter=;
 dateFormat=MM/dd/yy HH:mm
+processEmptyAssociations=false
+singleByteEncoding=false
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Section 5 -- Performance

--- a/src/test/resources/unitTest/unitTest.properties
+++ b/src/test/resources/unitTest/unitTest.properties
@@ -37,6 +37,7 @@ tearsheetExistField=name
 listDelimiter=;
 dateFormat=MM/dd/yyyy HH:mm:ss.SSS
 processEmptyAssociations=false
+singleByteEncoding=false
 
 numThreads=10
 


### PR DESCRIPTION
##### Description

Files that are already encoded in ISO-8859-1 (single-byte) encoding can
now be read in without having to convert to UTF-8 (multi-byte). UTF-8 is
still the default, but can now be overridden to single byte encoding.
