### PR TITLE
fix(Log): Added wildcard matching to logfile printout

### DIFF
--- a/src/main/java/com/bullhorn/dataloader/util/PropertyFileUtil.java
+++ b/src/main/java/com/bullhorn/dataloader/util/PropertyFileUtil.java
@@ -430,6 +430,7 @@ public class PropertyFileUtil {
         logPropertyIfExists(properties, Property.LIST_DELIMITER.getName());
         logPropertyIfExists(properties, Property.DATE_FORMAT.getName());
         logPropertyIfExists(properties, Property.PROCESS_EMPTY_ASSOCIATIONS.getName());
+        logPropertyIfExists(properties, Property.WILDCARD_MATCHING.getName());
         logPropertyIfExists(properties, Property.SINGLE_BYTE_ENCODING.getName());
 
         printUtil.log("# Section 6 -- Performance");


### PR DESCRIPTION
##### Description

Fixed wildcard matching property not getting output in the log

##### What did you change?

Added it to the logfile settings printout
