### PR TITLE
chore!: Upgrade to Java 11

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,4 @@ indent_size = 4
 
 # Matches the exact files either package.json or .travis.yml
 [{package.json,.travis.yml}]
-indent_style = space
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: openjdk11
 cache:
   directories:
     - node_modules

--- a/dataloader.iml
+++ b/dataloader.iml
@@ -10,7 +10,7 @@
       <configuration />
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -54,7 +54,6 @@
     <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware.kryo:kryo:2.24.0" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware.minlog:minlog:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.objenesis:objenesis:2.1" level="project" />
     <orderEntry type="library" name="Maven: de.javakaffee:kryo-serializers:0.37" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware:kryo:3.0.3" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware:reflectasm:1.10.1" level="project" />
@@ -150,11 +149,14 @@
     <orderEntry type="library" name="Maven: org.opengis:geoapi:3.0.0" level="project" />
     <orderEntry type="library" name="Maven: javax.measure:jsr-275:0.9.3" level="project" />
     <orderEntry type="library" name="Maven: net.sourceforge.javacsv:javacsv:2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.17.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.17.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.17.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.17.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.10.19" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:4.5.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.12.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.12.9" level="project" />
+    <orderEntry type="library" name="Maven: org.objenesis:objenesis:3.2" level="project" />
     <orderEntry type="library" name="Maven: javax.xml.bind:jaxb-api:2.3.1" level="project" />
     <orderEntry type="library" name="Maven: javax.activation:javax.activation-api:1.2.0" level="project" />
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.17.2</version>
         </dependency>
 
         <dependency>
@@ -58,28 +58,18 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
 
-        <!-- For Java 11 compatibility -->
+        <!-- For compatibility with older java 1.8 used in sdk-rest -->
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
         </dependency>
     </dependencies>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-            </plugin>
-        </plugins>
-    </reporting>
 
     <build>
         <plugins>
@@ -101,25 +91,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -169,29 +143,6 @@
                         <format>zip</format>
                     </formats>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.2.0</version>
-                <configuration>
-                    <!--suppress UnresolvedMavenProperty -->
-                    <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
-                    <serviceName>travis-pro</serviceName>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.7.201606060606</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -261,6 +212,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- For showing available updates using: mvn versions:display-dependency-updates -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.9.0</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/bullhorn/dataloader/rest/RestApiExtension.java
+++ b/src/main/java/com/bullhorn/dataloader/rest/RestApiExtension.java
@@ -53,7 +53,7 @@ public class RestApiExtension {
                 sb.append("\tError occurred on field ").append(message.getPropertyName())
                     .append(" due to the following: ").append(message.getDetailMessage()).append("\n");
             }
-            throw new RestApiException("Error occurred when making " + response.getChangeType() + " REST call:\n" + sb.toString());
+            throw new RestApiException("Error occurred when making " + response.getChangeType() + " REST call:\n" + sb);
         }
     }
 

--- a/src/test/java/com/bullhorn/dataloader/CommandLineInterfaceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/CommandLineInterfaceTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/bullhorn/dataloader/data/RowTest.java
+++ b/src/test/java/com/bullhorn/dataloader/data/RowTest.java
@@ -13,7 +13,7 @@ public class RowTest {
     public void testConstructor() {
         Row row = new Row("data/Candidate.csv", 1);
 
-        Assert.assertEquals(row.getNumber(), new Integer(1));
+        Assert.assertEquals(row.getNumber(), Integer.valueOf(1));
         Assert.assertEquals(row.getCells().size(), 0);
     }
 

--- a/src/test/java/com/bullhorn/dataloader/rest/CacheTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/CacheTest.java
@@ -1,6 +1,6 @@
 package com.bullhorn.dataloader.rest;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/bullhorn/dataloader/rest/CompleteUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/CompleteUtilTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.rest;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.contains;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/bullhorn/dataloader/rest/FieldTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/FieldTest.java
@@ -308,9 +308,9 @@ public class FieldTest {
         field.populateAssociationOnEntity(note, candidate2);
         field.populateAssociationOnEntity(note, candidate3);
 
-        Assert.assertEquals(note.getCandidates().getData().get(0).getId(), new Integer(101));
-        Assert.assertEquals(note.getCandidates().getData().get(1).getId(), new Integer(101));
-        Assert.assertEquals(note.getCandidates().getData().get(2).getId(), new Integer(101));
+        Assert.assertEquals(note.getCandidates().getData().get(0).getId(), Integer.valueOf(101));
+        Assert.assertEquals(note.getCandidates().getData().get(1).getId(), Integer.valueOf(101));
+        Assert.assertEquals(note.getCandidates().getData().get(2).getId(), Integer.valueOf(101));
 
         // The single value in the field will be set for each populated To-Many object
         Assert.assertEquals(field.getStringValueFromEntity(note, ";"), "101;101;101");
@@ -423,7 +423,7 @@ public class FieldTest {
 
         field.populateFieldOnEntity(candidate);
 
-        Assert.assertEquals(candidate.getAddress().getCountryID(), new Integer(1234));
+        Assert.assertEquals(candidate.getAddress().getCountryID(), Integer.valueOf(1234));
     }
 
     @Test

--- a/src/test/java/com/bullhorn/dataloader/rest/PreloaderTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/PreloaderTest.java
@@ -1,8 +1,8 @@
 package com.bullhorn.dataloader.rest;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/rest/RecordTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/RecordTest.java
@@ -43,7 +43,7 @@ public class RecordTest {
         Set<String> expectedParameters = Sets.newHashSet("externalID", "firstName", "lastName", "name", "email", "primarySkills(id)");
 
         Assert.assertEquals(EntityInfo.CANDIDATE, record.getEntityInfo());
-        Assert.assertEquals(new Integer(1), record.getNumber());
+        Assert.assertEquals(Integer.valueOf(1), record.getNumber());
         Assert.assertEquals(6, record.getFields().size());
         Assert.assertEquals(1, record.getToManyFields().size());
         Assert.assertEquals(expectedParameters, record.getFieldsParameter());

--- a/src/test/java/com/bullhorn/dataloader/rest/RestApiExtensionTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/RestApiExtensionTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.rest;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/rest/RestApiTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/RestApiTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.rest;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/rest/RestSessionTest.java
+++ b/src/test/java/com/bullhorn/dataloader/rest/RestSessionTest.java
@@ -2,12 +2,12 @@ package com.bullhorn.dataloader.rest;
 
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import com.bullhorn.dataloader.util.PrintUtil;
 import com.bullhorn.dataloader.util.PropertyFileUtil;
@@ -45,12 +45,13 @@ public class RestSessionTest {
     }
 
     @Test
-    public void testConnectExistingSession() {
-        RestSession restSessionPartialMock = mock(RestSession.class);
-        Whitebox.setInternalState(restSessionPartialMock, "restApi", restApiMock);
-        when(restSessionPartialMock.getRestApi()).thenCallRealMethod();
+    public void testConnectExistingSession() throws NoSuchFieldException, IllegalAccessException {
+        RestSession restSession = new RestSession(restApiExtensionMock, propertyFileUtilMock, printUtilMock);
+        Field privateField = restSession.getClass().getDeclaredField("restApi");
+        privateField.setAccessible(true);
+        privateField.set(restSession, restApiMock);
 
-        RestApi restApi = restSessionPartialMock.getRestApi();
+        RestApi restApi = restSession.getRestApi();
 
         Assert.assertEquals(restApi, restApiMock);
     }

--- a/src/test/java/com/bullhorn/dataloader/service/ConvertAttachmentsServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/ConvertAttachmentsServiceTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/src/test/java/com/bullhorn/dataloader/service/DeleteAttachmentsServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/DeleteAttachmentsServiceTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/src/test/java/com/bullhorn/dataloader/service/DeleteServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/DeleteServiceTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/src/test/java/com/bullhorn/dataloader/service/ExportServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/ExportServiceTest.java
@@ -1,8 +1,8 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/service/LoadAttachmentsServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/LoadAttachmentsServiceTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/src/test/java/com/bullhorn/dataloader/service/LoadServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/LoadServiceTest.java
@@ -1,9 +1,9 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/service/LoginServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/LoginServiceTest.java
@@ -1,6 +1,6 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/bullhorn/dataloader/service/MetaServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/MetaServiceTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/service/ProcessRunnerTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/ProcessRunnerTest.java
@@ -1,8 +1,8 @@
 package com.bullhorn.dataloader.service;
 
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/service/TemplateServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/TemplateServiceTest.java
@@ -1,8 +1,8 @@
 package com.bullhorn.dataloader.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/task/ConvertAttachmentTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/ConvertAttachmentTaskTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/bullhorn/dataloader/task/DeleteAttachmentTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/DeleteAttachmentTaskTest.java
@@ -1,9 +1,8 @@
 package com.bullhorn.dataloader.task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,7 +54,7 @@ public class DeleteAttachmentTaskTest {
             "testResume/TestResume.doc,0,1");
         StandardFileApiResponse fileApiResponse = new StandardFileApiResponse();
         fileApiResponse.setFileId(0);
-        when(restApiMock.deleteFile(anyObject(), anyInt(), anyInt())).thenReturn(fileApiResponse);
+        when(restApiMock.deleteFile(any(), anyInt(), anyInt())).thenReturn(fileApiResponse);
 
         DeleteAttachmentTask task = new DeleteAttachmentTask(EntityInfo.CANDIDATE, row, csvFileWriterMock,
             propertyFileUtilMock, restApiMock, printUtilMock, actionTotalsMock, cacheMock, completeUtilMock);

--- a/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/DeleteTaskTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/bullhorn/dataloader/task/ExportTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/ExportTaskTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -85,7 +85,7 @@ public class ExportTaskTest {
         TestUtils.verifyActionTotals(actionTotalsMock, Result.Action.EXPORT, 1);
         Row actualRow = rowArgumentCaptor.getValue();
         Assert.assertEquals("path/to/fake/file.csv", actualRow.getFilePath());
-        Assert.assertEquals(new Integer(1), actualRow.getNumber());
+        Assert.assertEquals(Integer.valueOf(1), actualRow.getNumber());
         Assert.assertEquals(row.getNames(), actualRow.getNames());
         Assert.assertEquals(Arrays.asList("11", "", "Sir", "Lancelot", "lancelot@spam.egg", "bo staff skills;hacking skills", "", "12345", ""), actualRow.getValues());
     }
@@ -126,7 +126,7 @@ public class ExportTaskTest {
         TestUtils.verifyActionTotals(actionTotalsMock, Result.Action.EXPORT, 1);
         Row actualRow = rowArgumentCaptor.getValue();
         Assert.assertEquals("path/to/fake/file.csv", actualRow.getFilePath());
-        Assert.assertEquals(new Integer(1), actualRow.getNumber());
+        Assert.assertEquals(Integer.valueOf(1), actualRow.getNumber());
         Assert.assertEquals(row.getNames(), actualRow.getNames());
         Assert.assertEquals(Arrays.asList("ext-1001", "skill_1;skill_2;skill_3;skill_4;skill_5;skill_6;skill_7"), actualRow.getValues());
     }

--- a/src/test/java/com/bullhorn/dataloader/task/LoadAttachmentTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadAttachmentTaskTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
+++ b/src/test/java/com/bullhorn/dataloader/task/LoadTaskTest.java
@@ -1,7 +1,7 @@
 package com.bullhorn.dataloader.task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/bullhorn/dataloader/util/PrintUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/PrintUtilTest.java
@@ -1,8 +1,9 @@
 package com.bullhorn.dataloader.util;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.contains;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,7 +15,6 @@ import java.io.PrintStream;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import com.bullhorn.dataloader.data.ActionTotals;
 import com.bullhorn.dataloader.data.Result;
@@ -47,8 +47,8 @@ public class PrintUtilTest {
         printUtil.printActionTotals(Command.CONVERT_ATTACHMENTS, totals);
 
         verify(printUtil, times(1)).printAndLog("Results of DataLoader run");
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("Start time: "));
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("End time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("Start time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("End time: "));
         verify(printUtil, times(1)).printAndLog("Args: convertAttachments candidateAttachFile.csv");
         verify(printUtil, times(1)).printAndLog("Total records processed: " + total);
         verify(printUtil, times(1)).printAndLog("Total records converted: " + totals.getActionTotal(Result.Action.CONVERT));
@@ -68,8 +68,8 @@ public class PrintUtilTest {
         printUtil.printActionTotals(Command.DELETE, totals);
 
         verify(printUtil, times(1)).printAndLog("Results of DataLoader run");
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("Start time: "));
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("End time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("Start time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("End time: "));
         verify(printUtil, times(1)).printAndLog("Args: delete candidate.csv");
         verify(printUtil, times(1)).printAndLog("Total records processed: " + total);
         verify(printUtil, times(1)).printAndLog("Total records deleted: " + totals.getActionTotal(Result.Action.DELETE));
@@ -88,8 +88,8 @@ public class PrintUtilTest {
         printUtil.printActionTotals(Command.DELETE_ATTACHMENTS, totals);
 
         verify(printUtil, times(1)).printAndLog("Results of DataLoader run");
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("Start time: "));
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("End time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("Start time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("End time: "));
         verify(printUtil, times(1)).printAndLog("Args: deleteAttachments candidateAttachments.csv");
         verify(printUtil, times(1)).printAndLog("Total records processed: " + total);
         verify(printUtil, times(1)).printAndLog("Total records deleted: " + totals.getActionTotal(Result.Action.DELETE));
@@ -108,8 +108,8 @@ public class PrintUtilTest {
         printUtil.printActionTotals(Command.EXPORT, totals);
 
         verify(printUtil, times(1)).printAndLog("Results of DataLoader run");
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("Start time: "));
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("End time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("Start time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("End time: "));
         verify(printUtil, times(1)).printAndLog("Args: export candidate.csv");
         verify(printUtil, times(1)).printAndLog("Total records processed: " + total);
         verify(printUtil, times(1)).printAndLog("Total records exported: " + totals.getActionTotal(Result.Action.CONVERT));
@@ -128,8 +128,8 @@ public class PrintUtilTest {
         printUtil.printActionTotals(Command.LOAD, totals);
 
         verify(printUtil, times(1)).printAndLog("Results of DataLoader run");
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("Start time: "));
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("End time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("Start time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("End time: "));
         verify(printUtil, times(1)).printAndLog("Args: load candidate.csv");
         verify(printUtil, times(1)).printAndLog("Total records processed: " + total);
         verify(printUtil, times(1)).printAndLog("Total records inserted: " + totals.getActionTotal(Result.Action.INSERT));
@@ -150,8 +150,8 @@ public class PrintUtilTest {
         printUtil.printActionTotals(Command.LOAD_ATTACHMENTS, totals);
 
         verify(printUtil, times(1)).printAndLog("Results of DataLoader run");
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("Start time: "));
-        verify(printUtil, times(1)).printAndLog(Matchers.startsWith("End time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("Start time: "));
+        verify(printUtil, times(1)).printAndLog(startsWith("End time: "));
         verify(printUtil, times(1)).printAndLog("Args: loadAttachments candidateAttachments.csv");
         verify(printUtil, times(1)).printAndLog("Total records processed: " + total);
         verify(printUtil, times(1)).printAndLog("Total records inserted: " + totals.getActionTotal(Result.Action.INSERT));

--- a/src/test/java/com/bullhorn/dataloader/util/PropertyFileUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/PropertyFileUtilTest.java
@@ -75,9 +75,9 @@ public class PropertyFileUtilTest {
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getExecuteFormTriggers());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getWildcardMatching());
         Assert.assertNull(propertyFileUtil.getEntity());
-        Assert.assertEquals(new Integer(10), propertyFileUtil.getNumThreads());
+        Assert.assertEquals(Integer.valueOf(10), propertyFileUtil.getNumThreads());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getCaching());
-        Assert.assertEquals(new Integer(0), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
+        Assert.assertEquals(Integer.valueOf(0), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getVerbose());
     }
 
@@ -134,9 +134,9 @@ public class PropertyFileUtilTest {
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getExecuteFormTriggers());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getWildcardMatching());
         Assert.assertNull(propertyFileUtil.getEntity());
-        Assert.assertEquals(new Integer(5), propertyFileUtil.getNumThreads());
+        Assert.assertEquals(Integer.valueOf(5), propertyFileUtil.getNumThreads());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getCaching());
-        Assert.assertEquals(new Integer(15), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
+        Assert.assertEquals(Integer.valueOf(15), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getVerbose());
     }
 
@@ -192,12 +192,12 @@ public class PropertyFileUtilTest {
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getExecuteFormTriggers());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getWildcardMatching());
         Assert.assertNull(propertyFileUtil.getEntity());
-        Assert.assertEquals(new Integer(6), propertyFileUtil.getNumThreads());
+        Assert.assertEquals(Integer.valueOf(6), propertyFileUtil.getNumThreads());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getCaching());
-        Assert.assertEquals(new Integer(20), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
+        Assert.assertEquals(Integer.valueOf(20), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getResultsFileEnabled());
         Assert.assertEquals("./results.json", propertyFileUtil.getResultsFilePath());
-        Assert.assertEquals(new Integer(500), propertyFileUtil.getResultsFileWriteIntervalMsec());
+        Assert.assertEquals(Integer.valueOf(500), propertyFileUtil.getResultsFileWriteIntervalMsec());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getVerbose());
     }
 
@@ -291,12 +291,12 @@ public class PropertyFileUtilTest {
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getExecuteFormTriggers());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getWildcardMatching());
         Assert.assertEquals(EntityInfo.CANDIDATE, propertyFileUtil.getEntity());
-        Assert.assertEquals(new Integer(7), propertyFileUtil.getNumThreads());
+        Assert.assertEquals(Integer.valueOf(7), propertyFileUtil.getNumThreads());
         Assert.assertEquals(Boolean.FALSE, propertyFileUtil.getCaching());
-        Assert.assertEquals(new Integer(25), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
+        Assert.assertEquals(Integer.valueOf(25), propertyFileUtil.getWaitSecondsBetweenFilesInDirectory());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getResultsFileEnabled());
         Assert.assertEquals("../results/output.json", propertyFileUtil.getResultsFilePath());
-        Assert.assertEquals(new Integer(100), propertyFileUtil.getResultsFileWriteIntervalMsec());
+        Assert.assertEquals(Integer.valueOf(100), propertyFileUtil.getResultsFileWriteIntervalMsec());
         Assert.assertEquals(Boolean.TRUE, propertyFileUtil.getVerbose());
     }
 

--- a/src/test/java/com/bullhorn/dataloader/util/PropertyValidationUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/PropertyValidationUtilTest.java
@@ -133,19 +133,19 @@ public class PropertyValidationUtilTest {
     @Test
     public void testMissingIntervalMsec() {
         Integer value = PropertyValidationUtil.validateIntervalMsec(null);
-        Assert.assertEquals(new Integer(500), value);
+        Assert.assertEquals(Integer.valueOf(500), value);
     }
 
     @Test
     public void testValidIntervalMsec() {
         Integer value = PropertyValidationUtil.validateIntervalMsec("250");
-        Assert.assertEquals(new Integer(250), value);
+        Assert.assertEquals(Integer.valueOf(250), value);
     }
 
     @Test
     public void testValidateNumThreads() {
         Integer actual = PropertyValidationUtil.validateNumThreads(0);
-        Assert.assertNotEquals(actual, new Integer(0));
+        Assert.assertNotEquals(actual, Integer.valueOf(0));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/bullhorn/dataloader/util/ValidationUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/ValidationUtilTest.java
@@ -1,6 +1,6 @@
 package com.bullhorn.dataloader.util;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
BREAKING CHANGE: Will require installing Java version 11 or higher before running.

##### Description

Upgrade Data Loader to Java version 11


##### What did you change?

Removed jacoco and coveralls reporting from the POM file. Updated to latest Mockito. Fixed almost all deprecated and code inspection issues.
