### PR TITLE
feat(Java8): Reverted back to Java version 8, since it works universally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk11
+jdk: openjdk8
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _The app handles loading data only. For features such as exporting and deleting 
 
  1. Install Java if you don't have it already (you won't need the development kit for Windows) - [Windows](http://javadl.oracle.com/webapps/download/AutoDL?BundleId=210182) | [Mac](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
  
-    1. Verify that you have a compatible version of java on the command line by typing: `java -version`, which should show: `java version "11.x.x"` or newer
+    1. Verify that you have a compatible version of java on the command line by typing: `java -version`, which should show: `java version "1.8.x"`
 
  2. Download the dataloader.zip file from the downloads section of the [Latest Release](https://github.com/bullhorn/dataloader/releases/latest)
  

--- a/dataloader.iml
+++ b/dataloader.iml
@@ -10,7 +10,7 @@
       <configuration />
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
##### Description

This will avoid users of the App from having to upgrade their version of java to the 11 JDK, which could be a huge pain.

##### What did you change?

Using Java 8 to compile Data Loader once again for compatibility



