### PR TITLE
feat(Meta): Fixed meta for properly loading Simplified Options Lookup fields from the Desktop App

### DIFF
--- a/src/main/java/com/bullhorn/dataloader/service/MetaService.java
+++ b/src/main/java/com/bullhorn/dataloader/service/MetaService.java
@@ -17,6 +17,7 @@ import com.bullhorn.dataloader.util.MethodUtil;
 import com.bullhorn.dataloader.util.PrintUtil;
 import com.bullhorn.dataloader.util.StringConsts;
 import com.bullhorn.dataloader.util.ValidationUtil;
+import com.bullhornsdk.data.model.entity.core.paybill.optionslookup.SimplifiedOptionsLookup;
 import com.bullhornsdk.data.model.entity.meta.Field;
 import com.bullhornsdk.data.model.entity.meta.MetaData;
 import com.bullhornsdk.data.model.enums.MetaParameter;
@@ -82,13 +83,19 @@ public class MetaService implements Action {
             List<Field> fields = metaData.getFields();
             Map<String, Method> setterMethodMap = MethodUtil.getSetterMethodMap(entityInfo.getEntityClass());
 
-            // Throw out fields in meta that are not in the SDK
             List<Field> fieldsToRemove = new ArrayList<>();
             for (Field field : fields) {
+                // Throw out fields in meta that are not in the SDK
                 if (!setterMethodMap.containsKey(field.getName().toLowerCase())) {
                     fieldsToRemove.add(field);
                     printUtil.log("Removed " + entityInfo.getEntityName() + " field: "
                         + field.getName() + " that does not exist in SDK-REST.");
+                }
+
+                // SimplifiedOptionsLookup should be treated as a direct field on the entity, since it is sent over as an id within an object
+                if (SimplifiedOptionsLookup.class.getSimpleName().equals(field.getDataType())) {
+                    field.setAssociatedEntity(null);
+                    field.setType(StringConsts.SCALAR);
                 }
             }
             fields.removeAll(fieldsToRemove);

--- a/src/main/java/com/bullhorn/dataloader/util/AssociationUtil.java
+++ b/src/main/java/com/bullhorn/dataloader/util/AssociationUtil.java
@@ -97,16 +97,23 @@ public class AssociationUtil {
      * @return either the current entity or the associated entity
      */
     public static EntityInfo getFieldEntity(EntityInfo entityInfo, Cell cell) {
+        EntityInfo fieldEntityInfo = entityInfo;
+
         if (cell.isAssociation()) {
             if (isToMany(entityInfo, cell.getAssociationBaseName())) {
                 AssociationField associationField = getToManyField(entityInfo, cell.getAssociationBaseName());
-                return EntityInfo.fromString(associationField.getAssociationType().getSimpleName());
+                fieldEntityInfo = EntityInfo.fromString(associationField.getAssociationType().getSimpleName());
             } else {
                 Method setMethod = MethodUtil.getSetterMethod(entityInfo, cell.getAssociationBaseName());
-                return EntityInfo.fromString(setMethod.getParameterTypes()[0].getSimpleName());
+                fieldEntityInfo = EntityInfo.fromString(setMethod.getParameterTypes()[0].getSimpleName());
             }
         }
-        return entityInfo;
+
+        if (fieldEntityInfo == null) {
+            throw new RestApiException("Error getting the associated entity for field: '" + cell.getName() + "'. Check that the field is valid.");
+        }
+
+        return fieldEntityInfo;
     }
 
     /**

--- a/src/main/java/com/bullhorn/dataloader/util/StringConsts.java
+++ b/src/main/java/com/bullhorn/dataloader/util/StringConsts.java
@@ -30,6 +30,7 @@ public class StringConsts {
     public static final String PROPERTY_FILE_ARG = "propertyfile";
     public static final String RELATIVE_FILE_PATH = "relativeFilePath";
     public static final String TIMESTAMP = DateUtil.getTimestamp();
-    public static final String TO_MANY = "TO_MANY";
+    public static final String SCALAR = "SCALAR";
     public static final String TO_ONE = "TO_ONE";
+    public static final String TO_MANY = "TO_MANY";
 }

--- a/src/test/java/com/bullhorn/dataloader/util/AssociationUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/AssociationUtilTest.java
@@ -102,4 +102,10 @@ public class AssociationUtilTest {
         EntityInfo entityInfo = AssociationUtil.getFieldEntity(EntityInfo.CANDIDATE, cell);
         Assert.assertEquals(EntityInfo.CANDIDATE, entityInfo);
     }
+
+    @Test(expected = RestApiException.class)
+    public void testGetFieldEntityInvalidAssociation() {
+        Cell cell = new Cell("name.first", "bill");
+        AssociationUtil.getFieldEntity(EntityInfo.CANDIDATE, cell);
+    }
 }


### PR DESCRIPTION
##### Description

Fixes the meta for loading fields like bteSyncStatus from the Desktop App

##### What did you change?

Fixed meta to be the scalar field we need it to be in Data Loader
Better warning thrown for encountering this error than the previous (nullPtrException)

