### PR TITLE
fix(WorkersCompensationRate): Ensuring that privateLabel.id is available in meta

### DIFF
--- a/src/main/java/com/bullhorn/dataloader/service/MetaService.java
+++ b/src/main/java/com/bullhorn/dataloader/service/MetaService.java
@@ -106,7 +106,7 @@ public class MetaService implements Action {
             // Add additional fields from SDK-REST that are not in meta
             if (setterMethodMap.containsKey(StringConsts.EXTERNAL_ID.toLowerCase())
                 && fields.stream().noneMatch(field -> field.getName().equals(StringConsts.EXTERNAL_ID))) {
-                fields.add(createField(StringConsts.PRIVATE_LABEL, StringConsts.EXTERNAL_ID, "SCALAR", "String"));
+                fields.add(createField(StringConsts.EXTERNAL_ID, StringConsts.EXTERNAL_ID, "SCALAR", "String"));
                 printUtil.log("Added " + entityInfo.getEntityName() + " field: "
                     + StringConsts.EXTERNAL_ID + " that was not in Meta.");
             }

--- a/src/main/java/com/bullhorn/dataloader/service/MetaService.java
+++ b/src/main/java/com/bullhorn/dataloader/service/MetaService.java
@@ -111,7 +111,6 @@ public class MetaService implements Action {
                     + StringConsts.EXTERNAL_ID + " that was not in Meta.");
             }
             if (entityInfo.equals(EntityInfo.WORKERS_COMPENSATION_RATE)
-                && setterMethodMap.containsKey(StringConsts.PRIVATE_LABEL.toLowerCase())
                 && fields.stream().noneMatch(field -> field.getName().equals(StringConsts.PRIVATE_LABEL))) {
                 StandardMetaData<PrivateLabel> associatedEntityMeta = new StandardMetaData<>();
                 associatedEntityMeta.setEntity("PrivateLabel");

--- a/src/main/java/com/bullhorn/dataloader/service/MetaService.java
+++ b/src/main/java/com/bullhorn/dataloader/service/MetaService.java
@@ -2,6 +2,7 @@ package com.bullhorn.dataloader.service;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -18,8 +19,10 @@ import com.bullhorn.dataloader.util.PrintUtil;
 import com.bullhorn.dataloader.util.StringConsts;
 import com.bullhorn.dataloader.util.ValidationUtil;
 import com.bullhornsdk.data.model.entity.core.paybill.optionslookup.SimplifiedOptionsLookup;
+import com.bullhornsdk.data.model.entity.core.standard.PrivateLabel;
 import com.bullhornsdk.data.model.entity.meta.Field;
 import com.bullhornsdk.data.model.entity.meta.MetaData;
+import com.bullhornsdk.data.model.entity.meta.StandardMetaData;
 import com.bullhornsdk.data.model.enums.MetaParameter;
 import com.google.common.collect.Sets;
 
@@ -103,13 +106,23 @@ public class MetaService implements Action {
             // Add additional fields from SDK-REST that are not in meta
             if (setterMethodMap.containsKey(StringConsts.EXTERNAL_ID.toLowerCase())
                 && fields.stream().noneMatch(field -> field.getName().equals(StringConsts.EXTERNAL_ID))) {
-                Field externalIdField = new Field();
-                externalIdField.setName(StringConsts.EXTERNAL_ID);
-                externalIdField.setType("SCALAR");
-                externalIdField.setDataType("String");
-                fields.add(externalIdField);
+                fields.add(createField(StringConsts.PRIVATE_LABEL, StringConsts.EXTERNAL_ID, "SCALAR", "String"));
                 printUtil.log("Added " + entityInfo.getEntityName() + " field: "
                     + StringConsts.EXTERNAL_ID + " that was not in Meta.");
+            }
+            if (entityInfo.equals(EntityInfo.WORKERS_COMPENSATION_RATE)
+                && setterMethodMap.containsKey(StringConsts.PRIVATE_LABEL.toLowerCase())
+                && fields.stream().noneMatch(field -> field.getName().equals(StringConsts.PRIVATE_LABEL))) {
+                StandardMetaData<PrivateLabel> associatedEntityMeta = new StandardMetaData<>();
+                associatedEntityMeta.setEntity("PrivateLabel");
+                associatedEntityMeta.setLabel("Private Label");
+                associatedEntityMeta.setFields(new ArrayList<>(Collections.singletonList(
+                    createField(StringConsts.ID, "ID", "ID", "Integer"))));
+                Field privateLabelField = createField(StringConsts.PRIVATE_LABEL, "Private Label", "TO_ONE", null);
+                privateLabelField.setAssociatedEntity(associatedEntityMeta);
+                fields.add(privateLabelField);
+                printUtil.log("Added " + entityInfo.getEntityName() + " field: "
+                    + StringConsts.PRIVATE_LABEL + " that was not in Meta.");
             }
         }
     }
@@ -147,5 +160,17 @@ public class MetaService implements Action {
             jsonFields.put(jsonField);
         }
         return jsonFields;
+    }
+
+    /**
+     * Convenience constructor that builds up a small Field object.
+     */
+    private static Field createField(String name, String label, String type, String dataType) {
+        Field field = new Field();
+        field.setName(name);
+        field.setLabel(label);
+        field.setType(type);
+        field.setDataType(dataType);
+        return field;
     }
 }

--- a/src/main/java/com/bullhorn/dataloader/util/StringConsts.java
+++ b/src/main/java/com/bullhorn/dataloader/util/StringConsts.java
@@ -28,6 +28,7 @@ public class StringConsts {
     public static final String NAME = "name";
     public static final String NOTE_ID = "noteID";
     public static final String PARENT_ENTITY_ID = "parentEntityID";
+    public static final String PRIVATE_LABEL = "privateLabel";
     public static final String PROPERTY_FILE_ARG = "propertyfile";
     public static final String RELATIVE_FILE_PATH = "relativeFilePath";
     public static final String TIMESTAMP = DateUtil.getTimestamp();

--- a/src/test/java/com/bullhorn/dataloader/service/MetaServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/MetaServiceTest.java
@@ -125,6 +125,7 @@ public class MetaServiceTest {
         Assert.assertEquals(meta.get("entity"), "Candidate");
         Assert.assertEquals(meta.get("label"), "Employee");
         JSONArray fields = meta.getJSONArray("fields");
+        Assert.assertEquals(7, fields.length());
         TestUtils.checkJsonObject(fields.getJSONObject(0), "name", "id");
         TestUtils.checkJsonObject(fields.getJSONObject(1), "name,label,description,hint", "email,Email,,");
         TestUtils.checkJsonObject(fields.getJSONObject(2), "name,label,description,hint",
@@ -165,6 +166,7 @@ public class MetaServiceTest {
         Assert.assertEquals(meta.get("entity"), "Placement");
         Assert.assertEquals(meta.get("label"), "Placement");
         JSONArray fields = meta.getJSONArray("fields");
+        Assert.assertEquals(2, fields.length());
         TestUtils.checkJsonObject(fields.getJSONObject(0), "name", "id");
 
         JSONObject bteSyncStatusField = fields.getJSONObject(1);
@@ -189,6 +191,7 @@ public class MetaServiceTest {
         Assert.assertEquals(meta.get("entity"), "WorkersCompensationRate");
         Assert.assertEquals(meta.get("label"), "Workers Compensation Rate");
         JSONArray fields = meta.getJSONArray("fields");
+        Assert.assertEquals(3, fields.length());
         TestUtils.checkJsonObject(fields.getJSONObject(0), "name,label,type,dataType", "id,ID,ID,Integer");
         TestUtils.checkJsonObject(fields.getJSONObject(1), "name,label,type,dataType", "startDate,Start Date,SCALAR,Timestamp");
 


### PR DESCRIPTION
##### Description

Fixing an issue in the App where the privateLabel.id is not assignable for WorkerCompRate

##### What did you change?

Ensuring it's correctly in meta, even if the backend doesn't return the field.