### PR TITLE
fix(App): Using file output to workaround issues in windows java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ coverage/
 convertedAttachments/
 integrationTest.sh
 /*.csv
+/login.txt
+/meta.json
 
 ######################
 # Maven

--- a/src/main/java/com/bullhorn/dataloader/rest/CompleteUtil.java
+++ b/src/main/java/com/bullhorn/dataloader/rest/CompleteUtil.java
@@ -1,6 +1,7 @@
 package com.bullhorn.dataloader.rest;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -137,7 +138,7 @@ public class CompleteUtil {
         try {
             String resultsString = resultsWrapper.get().toString(2);
             File file = new File(propertyFileUtil.getResultsFilePath());
-            FileUtils.writeStringToFile(file, resultsString, "UTF-8");
+            FileUtils.writeStringToFile(file, resultsString, StandardCharsets.UTF_8);
         } catch (Exception e) {
             printUtil.printAndLog("Error writing results file: " + e);
         }

--- a/src/main/java/com/bullhorn/dataloader/service/LoginService.java
+++ b/src/main/java/com/bullhorn/dataloader/service/LoginService.java
@@ -1,6 +1,7 @@
 package com.bullhorn.dataloader.service;
 
 import com.bullhorn.dataloader.rest.RestSession;
+import com.bullhorn.dataloader.util.FileUtil;
 import com.bullhorn.dataloader.util.PrintUtil;
 
 /**
@@ -18,16 +19,22 @@ public class LoginService implements Action {
 
     @Override
     public void run(String[] args) {
-        try {
-            restSession.getRestApi();
-            printUtil.printAndLog("Login Successful");
-        } catch (Exception e) {
-            printUtil.printAndLog("Login Failed");
-        }
+        String output = isLoginSuccessful() ? "Login Successful" : "Login Failed";
+        printUtil.printAndLog(output);
+        FileUtil.writeStringToFileAndLogException("login.txt", output, printUtil);
     }
 
     @Override
     public boolean isValidArguments(String[] args) {
+        return true;
+    }
+
+    private boolean isLoginSuccessful() {
+        try {
+            restSession.getRestApi();
+        } catch (Exception e) {
+            return false;
+        }
         return true;
     }
 }

--- a/src/main/java/com/bullhorn/dataloader/service/MetaService.java
+++ b/src/main/java/com/bullhorn/dataloader/service/MetaService.java
@@ -43,17 +43,19 @@ public class MetaService implements Action {
     @SuppressWarnings("unchecked")
     public void run(String[] args) {
         EntityInfo entityInfo = FileUtil.extractEntityFromFileName(args[1]);
+        String entityName = Objects.requireNonNull(entityInfo).getEntityName();
         RestApi restApi = restSession.getRestApi();
 
         try {
-            printUtil.log("Getting meta for " + Objects.requireNonNull(entityInfo).getEntityName() + "...");
+            printUtil.log("Getting meta for " + entityName + "...");
             MetaData<?> metaData = restApi.getMetaData(entityInfo.getEntityClass(), MetaParameter.FULL, Sets.newHashSet(StringConsts.ALL_FIELDS));
             enrichMeta(metaData);
-            JSONObject jsonMeta = metaToJson(metaData);
-            printUtil.print(jsonMeta.toString());
-            printUtil.log("Done generating meta for " + Objects.requireNonNull(entityInfo).getEntityName());
+            String jsonString = metaToJson(metaData).toString();
+            printUtil.print(jsonString);
+            FileUtil.writeStringToFileAndLogException("meta.json", jsonString, printUtil);
+            printUtil.log("Done generating meta for " + entityName);
         } catch (Exception e) {
-            printUtil.printAndLog("ERROR: Failed to get Meta for " + Objects.requireNonNull(entityInfo).getEntityName());
+            printUtil.printAndLog("ERROR: Failed to get Meta for " + entityName);
             printUtil.printAndLog(e);
         }
     }

--- a/src/main/java/com/bullhorn/dataloader/util/FileUtil.java
+++ b/src/main/java/com/bullhorn/dataloader/util/FileUtil.java
@@ -1,6 +1,7 @@
 package com.bullhorn.dataloader.util;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 
 import com.bullhorn.dataloader.data.Row;
@@ -176,5 +178,17 @@ public class FileUtil {
             attachmentFile = new File(currentCsvFile.getParent(), row.getValue(StringConsts.RELATIVE_FILE_PATH));
         }
         return attachmentFile;
+    }
+
+    /**
+     * Shortcut for writing to a file and logging exceptions
+     */
+    public static void writeStringToFileAndLogException(String filename, String output, PrintUtil printUtil) {
+        try {
+            File file = new File(filename);
+            FileUtils.writeStringToFile(file, output, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            printUtil.log("Failed to write \"" + output + "\" to file: " + filename);
+        }
     }
 }

--- a/src/main/java/com/bullhorn/dataloader/util/MethodUtil.java
+++ b/src/main/java/com/bullhorn/dataloader/util/MethodUtil.java
@@ -138,7 +138,7 @@ public class MethodUtil {
     }
 
     /**
-     * Converts the given string value to the given type, and if it's a date, using the given dateTimeFormatter.
+     * Converts the given string value to the given type, and if it is a date, using the given dateTimeFormatter.
      * <p>
      * If the date is being used to query for existing records, then it does not need to be in the form of
      * the date time format, it can stay as a string until used in the find call.

--- a/src/test/java/com/bullhorn/dataloader/TestUtils.java
+++ b/src/test/java/com/bullhorn/dataloader/TestUtils.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -207,9 +208,9 @@ public class TestUtils {
             for (File file : directoryListing) {
                 String extension = FilenameUtils.getExtension(file.getPath());
                 if (extension.equalsIgnoreCase(StringConsts.CSV)) {
-                    String content = FileUtils.readFileToString(file, "UTF-8");
+                    String content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                     content = content.replaceAll(findText, replaceText);
-                    FileUtils.writeStringToFile(file, content, "UTF-8");
+                    FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);
                 } else if (file.isDirectory()) {
                     replaceTextInFiles(file, findText, replaceText);
                 }

--- a/src/test/java/com/bullhorn/dataloader/data/CsvFileReaderTest.java
+++ b/src/test/java/com/bullhorn/dataloader/data/CsvFileReaderTest.java
@@ -27,7 +27,7 @@ public class CsvFileReaderTest {
     public void setup() throws IOException {
         printUtilMock = mock(PrintUtil.class);
 
-        // Normally, we would mock out these low level dependencies, but it's in fact easier and more
+        // Normally, we would mock out these low level dependencies, but it is in fact easier and more
         // straightforward to use the real objects when testing.
         String path = TestUtils.getResourceFilePath("unitTest.properties");
         Map<String, String> envVars = new HashMap<>();

--- a/src/test/java/com/bullhorn/dataloader/integration/IntegrationTest.java
+++ b/src/test/java/com/bullhorn/dataloader/integration/IntegrationTest.java
@@ -2,6 +2,7 @@ package com.bullhorn.dataloader.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
@@ -78,10 +79,10 @@ public class IntegrationTest {
         // Test that incorrect capitalization will be fixed instead of cause errors
         runAllCommandsAgainstDirectory(TestUtils.getResourceFilePath("capitalization"));
 
-        // Test that the byte order mark is ignored when it's present in the input file as the first (hidden) character
+        // Test that the byte order mark is ignored when it is present in the input file as the first (hidden) character
         runAllCommandsAgainstDirectory(TestUtils.getResourceFilePath("byteOrderMark"));
 
-        // Test that country names are case insensitive
+        // Test that country names are case-insensitive
         runAllCommandsAgainstDirectory(TestUtils.getResourceFilePath("countryNames"));
 
         // Run a test for skipping updates (with the setting turned on)
@@ -142,7 +143,7 @@ public class IntegrationTest {
      * 7. Load - Update
      * 8. Delete
      * <p> <p>
-     * The unique IDs of all of the entities are changed from `-ext-1` to something unique, after the examples have been
+     * The unique IDs of entities are changed from `-ext-1` to something unique, after the examples have been
      * cloned to a test folder.
      * <p> <p>
      * Test assertions of both command line output and results files created. These steps cover the presence of records
@@ -172,7 +173,7 @@ public class IntegrationTest {
         // region LOAD - INSERT
         if (!skipInserts) {
             FileUtils.deleteQuietly(new File(CsvFileWriter.RESULTS_DIR)); // Cleanup from previous runs
-            System.setIn(IOUtils.toInputStream("yes", "UTF-8")); // Accepts command for entire directory
+            System.setIn(IOUtils.toInputStream("yes", StandardCharsets.UTF_8)); // Accepts command for entire directory
             consoleOutputCapturer.start();
             Main.main(new String[]{"load", tempDirPath});
             TestUtils.checkCommandLineOutput(consoleOutputCapturer.stop(), Result.Action.INSERT);
@@ -200,7 +201,7 @@ public class IntegrationTest {
             // endregion
 
             // region LOAD ATTACHMENTS - UPDATE
-            // Do not cleanup from previous run here - both Candidate and CandidateUpdate need to be present for delete step
+            // Do not clean up after previous run here - both Candidate and CandidateUpdate need to be present for delete step
             consoleOutputCapturer.start();
             Main.main(new String[]{"loadAttachments", tempAttachmentsDirectory.getPath() + "/CandidateUpdate.csv"});
             TestUtils.checkCommandLineOutput(consoleOutputCapturer.stop(), Result.Action.UPDATE);
@@ -220,7 +221,7 @@ public class IntegrationTest {
         // region EXPORT
         if (!skipExports) {
             FileUtils.deleteQuietly(new File(CsvFileWriter.RESULTS_DIR)); // Cleanup from previous runs
-            System.setIn(IOUtils.toInputStream("yes", "UTF-8")); // Accepts command for entire directory
+            System.setIn(IOUtils.toInputStream("yes", StandardCharsets.UTF_8)); // Accepts command for entire directory
             consoleOutputCapturer.start();
             Main.main(new String[]{"export", tempDirPath});
             TestUtils.checkCommandLineOutput(consoleOutputCapturer.stop(), Result.Action.EXPORT);
@@ -234,7 +235,7 @@ public class IntegrationTest {
             TestUtils.replaceTextInFiles(tempDirectory, "2001-01-01", "2002-02-02");
 
             FileUtils.deleteQuietly(new File(CsvFileWriter.RESULTS_DIR)); // Cleanup from previous runs
-            System.setIn(IOUtils.toInputStream("yes", "UTF-8")); // Accepts command for entire directory
+            System.setIn(IOUtils.toInputStream("yes", StandardCharsets.UTF_8)); // Accepts command for entire directory
             consoleOutputCapturer.start();
             Main.main(new String[]{"load", tempDirPath});
             Result.Action expectedAction = skipDuplicates ? Result.Action.SKIP : Result.Action.UPDATE;
@@ -248,7 +249,7 @@ public class IntegrationTest {
             // Capture results file directory state
             File[] resultsFiles = resultsDir.listFiles();
 
-            System.setIn(IOUtils.toInputStream("yes", "UTF-8")); // Accepts command for entire directory
+            System.setIn(IOUtils.toInputStream("yes", StandardCharsets.UTF_8)); // Accepts command for entire directory
             consoleOutputCapturer.start();
             Main.main(new String[]{"delete", CsvFileWriter.RESULTS_DIR});
             TestUtils.checkCommandLineOutput(consoleOutputCapturer.stop(), Result.Action.DELETE);

--- a/src/test/java/com/bullhorn/dataloader/service/DeleteServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/DeleteServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -41,7 +42,7 @@ public class DeleteServiceTest {
         actionTotalsMock = mock(ActionTotals.class);
         completeUtilMock = mock(CompleteUtil.class);
         RestSession restSessionMock = mock(RestSession.class);
-        InputStream inputStreamFake = IOUtils.toInputStream("yes", "UTF-8");
+        InputStream inputStreamFake = IOUtils.toInputStream("yes", StandardCharsets.UTF_8);
         printUtilMock = mock(PrintUtil.class);
         processRunnerMock = mock(ProcessRunner.class);
         PropertyFileUtil propertyFileUtilMock = mock(PropertyFileUtil.class);

--- a/src/test/java/com/bullhorn/dataloader/service/ExportServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/ExportServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -45,7 +46,7 @@ public class ExportServiceTest {
         actionTotalsMock = mock(ActionTotals.class);
         completeUtilMock = mock(CompleteUtil.class);
         restSessionMock = mock(RestSession.class);
-        inputStreamFake = IOUtils.toInputStream("Yes!", "UTF-8");
+        inputStreamFake = IOUtils.toInputStream("Yes!", StandardCharsets.UTF_8);
         printUtilMock = mock(PrintUtil.class);
         processRunnerMock = mock(ProcessRunner.class);
         propertyFileUtilMock = mock(PropertyFileUtil.class);
@@ -115,7 +116,7 @@ public class ExportServiceTest {
 
     @Test
     public void testRunDirectoryFourFilesContinueNo() throws Exception {
-        inputStreamFake = IOUtils.toInputStream("No", "UTF-8");
+        inputStreamFake = IOUtils.toInputStream("No", StandardCharsets.UTF_8);
         exportService = new ExportService(printUtilMock, propertyFileUtilMock, completeUtilMock, restSessionMock, processRunnerMock, inputStreamFake, timerMock);
 
         final String filePath = TestUtils.getResourceFilePath("loadFromDirectory");

--- a/src/test/java/com/bullhorn/dataloader/service/LoadServiceTest.java
+++ b/src/test/java/com/bullhorn/dataloader/service/LoadServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -46,7 +47,7 @@ public class LoadServiceTest {
         actionTotalsMock = mock(ActionTotals.class);
         completeUtilMock = mock(CompleteUtil.class);
         restSessionMock = mock(RestSession.class);
-        inputStreamFake = IOUtils.toInputStream("Yes!", "UTF-8");
+        inputStreamFake = IOUtils.toInputStream("Yes!", StandardCharsets.UTF_8);
         printUtilMock = mock(PrintUtil.class);
         processRunnerMock = mock(ProcessRunner.class);
         propertyFileUtilMock = mock(PropertyFileUtil.class);
@@ -131,7 +132,7 @@ public class LoadServiceTest {
 
     @Test
     public void testRunDirectoryFourFilesContinueNo() throws IOException, InterruptedException {
-        inputStreamFake = IOUtils.toInputStream("No", "UTF-8");
+        inputStreamFake = IOUtils.toInputStream("No", StandardCharsets.UTF_8);
         loadService = new LoadService(printUtilMock, propertyFileUtilMock, completeUtilMock, restSessionMock, processRunnerMock, inputStreamFake, timerMock);
 
         final String filePath = TestUtils.getResourceFilePath("loadFromDirectory");

--- a/src/test/java/com/bullhorn/dataloader/util/FileUtilTest.java
+++ b/src/test/java/com/bullhorn/dataloader/util/FileUtilTest.java
@@ -1,6 +1,8 @@
 package com.bullhorn.dataloader.util;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.util.Arrays;
@@ -22,10 +24,12 @@ import com.bullhorn.dataloader.enums.EntityInfo;
 @SuppressWarnings("InstantiationOfUtilityClass")
 public class FileUtilTest {
 
+    private PrintUtil printUtilMock;
     private PropertyFileUtil propertyFileUtilMock;
 
     @Before
     public void setup() {
+        printUtilMock = mock(PrintUtil.class);
         propertyFileUtilMock = mock(PropertyFileUtil.class);
     }
 
@@ -145,5 +149,11 @@ public class FileUtilTest {
     public void testIsCsvFileNonCsvFile() {
         String path = TestUtils.getResourceFilePath("unitTest.properties");
         Assert.assertFalse(FileUtil.isCsvFile(path));
+    }
+
+    @Test
+    public void testWriteStringToFileAndLogException() {
+        FileUtil.writeStringToFileAndLogException(null, "this should fail", printUtilMock);
+        verify(printUtilMock, times(1)).log("Failed to write \"this should fail\" to file: null");
     }
 }


### PR DESCRIPTION
##### Description

Workaround for issues in windows java version 411 no longer allowing stdout to be directed to the calling node app.

##### What did you change?

Add file output that matches stdout output
