### PR TITLE
fix(Build): Remove npm from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: java
 jdk: openjdk8
-cache:
-  directories:
-    - node_modules
-before_install:
-  - nvm install 16
-install:
-  - npm install
 script:
   - mvn verify
 after_success:


### PR DESCRIPTION
##### Description

Removes stuff that TravisCI now fails the build for - apparently the log file is too long and it aborts now.

##### What did you change?

Removed NPM from the build script, since we no longer need it for galaxy parsing.
